### PR TITLE
Use specific exception (NameError) for linters

### DIFF
--- a/pypykatz/crypto/aes/AES.py
+++ b/pypykatz/crypto/aes/AES.py
@@ -76,7 +76,7 @@ def _concat_list(a, b):
 # Python 3 compatibility
 try:
     xrange
-except Exception:
+except NameError:
     xrange = range
 
     # Python 3 supports bytes, which is already an array of integers

--- a/pypykatz/crypto/aes/util.py
+++ b/pypykatz/crypto/aes/util.py
@@ -36,7 +36,7 @@ def _get_byte(c):
 
 try:
     xrange
-except:
+except NameError:
 
     def to_bufferable(binary):
         if isinstance(binary, bytes):

--- a/pypykatz/crypto/des.py
+++ b/pypykatz/crypto/des.py
@@ -71,8 +71,8 @@ k = des("DESCRYPT", CBC, "\0\0\0\0\0\0\0\0", pad=None, padmode=PAD_PKCS5)
 #   data = b"Please encrypt my data"
 #   k = des(b"DESCRYPT", CBC, b"\0\0\0\0\0\0\0\0", pad=None, padmode=PAD_PKCS5)
 d = k.encrypt(data)
-print "Encrypted: %r" % d
-print "Decrypted: %r" % k.decrypt(d)
+print("Encrypted: %r" % d)
+print("Decrypted: %r" % k.decrypt(d))
 assert k.decrypt(d, padmode=PAD_PKCS5) == data
 
 


### PR DESCRIPTION
flake8 testing of https://github.com/skelsec/pypykatz on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./pypykatz/crypto/des.py:232:24: F821 undefined name 'unicode'
			if isinstance(data, unicode):
                       ^
./pypykatz/crypto/aes/AES.py:78:5: F821 undefined name 'xrange'
    xrange
    ^
./pypykatz/crypto/aes/util.py:38:5: F821 undefined name 'xrange'
    xrange
    ^
3     F821 undefined name 'xrange'
3
```