### PR TITLE
Added check for None tspkg primary_credentials.

### DIFF
--- a/pypykatz/lsadecryptor/packages/tspkg/decryptor.py
+++ b/pypykatz/lsadecryptor/packages/tspkg/decryptor.py
@@ -62,13 +62,13 @@ class TspkgDecryptor(PackageDecryptor):
 			self.reader.move(ptr)
 			credential_struct = self.decryptor_template.credential_struct(self.reader)
 			primary_credential = credential_struct.pTsPrimary.read(self.reader)
-			
-			c = TspkgCredential()
-			c.luid = credential_struct.LocallyUniqueIdentifier
-			c.username = primary_credential.credentials.UserName.read_string(self.reader)
-			c.domainname = primary_credential.credentials.Domaine.read_string(self.reader)
-			if primary_credential.credentials.Password.Length != 0:
-				enc_data = primary_credential.credentials.Password.read_maxdata(self.reader)
-				c.password = self.decrypt_password(enc_data)					
-			
-			self.credentials.append(c)
+			if not primary_credential is None:
+				c = TspkgCredential()
+				c.luid = credential_struct.LocallyUniqueIdentifier
+				c.username = primary_credential.credentials.UserName.read_string(self.reader)
+				c.domainname = primary_credential.credentials.Domaine.read_string(self.reader)
+				if primary_credential.credentials.Password.Length != 0:
+					enc_data = primary_credential.credentials.Password.read_maxdata(self.reader)
+					c.password = self.decrypt_password(enc_data)					
+				
+				self.credentials.append(c)


### PR DESCRIPTION
Hi, 

I've encountered an error while parsing a lsass dump. The following stacktrace was shown:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/.local/lib/python3.6/site-packages/pypykatz/pypykatz.py", line 51, in parse_minidump_file
    mimi.start()
  File "/home/user/.local/lib/python3.6/site-packages/pypykatz/pypykatz.py", line 137, in start
    self.get_tspkg()
  File "/home/user/.local/lib/python3.6/site-packages/pypykatz/pypykatz.py", line 80, in get_tspkg
    tspkg_dec.start()
  File "/home/user/.local/lib/python3.6/site-packages/pypykatz/lsadecryptor/packages/tspkg/decryptor.py", line 68, in start
    c.username = primary_credential.credentials.UserName.read_string(self.reader)
AttributeError: 'NoneType' object has no attribute 'credentials'

The (easy) fix is to check if the primary_credential is not None. This is implemented in this merge request.
