### PR TITLE
fix typo: nthash -> lmhash

### DIFF
--- a/pypykatz/registry/sam/sam.py
+++ b/pypykatz/registry/sam/sam.py
@@ -142,7 +142,7 @@ class SAM:
 			
 			elif uac.LM_hash and isinstance(uac.LM_hash, SAM_HASH):
 				if uac.LM_hash.hash != b'':
-					nthash = self.decrypt_hash(rid, uac.LM_hash, NTPASSWORD)
+					lmhash = self.decrypt_hash(rid, uac.LM_hash, LMPASSWORD)
 			
 			secret = SAMSecret(uac.name, int(rid,16), nthash, lmhash)
 			self.secrets.append(secret)


### PR DESCRIPTION
I noticed that pypykatz was yielding wrong values for the NT hash when using the `registry` submodule in my case. After examining some code, I noticed that the `nthash` variable is overwritten if there is a non-empty lmhash present. Probably a copy-paste mistake :)

After applying this patch, pypykatz returns the same values as `secretsdump.py`