### PR TITLE
Commented out print statement

### DIFF
--- a/pypykatz/pypykatz.py
+++ b/pypykatz/pypykatz.py
@@ -32,7 +32,7 @@ class pypykatz:
 		t = {}
 		t['logon_sessions'] = {}
 		for ls in self.logon_sessions:
-			print(ls)
+			# print(ls)
 			t['logon_sessions'][ls] = (self.logon_sessions[ls].to_dict())
 		t['orphaned_creds'] = []
 		for oc in self.orphaned_creds:


### PR DESCRIPTION
Whenever you json.dumps a parsed minidump, the logon session ids are getting printed as they are processed, which is a bit annoying.

![image](https://user-images.githubusercontent.com/2198138/73108915-ea125600-3ebe-11ea-8faf-2642bfb33ff9.png)

The UniversalEncoder calls a pypykatz object's 'to_dict' method, which is where the IDs are being printed. I figure this is just a debug statement that found its way to release. Commenting out this line removes this behavior.

![image](https://user-images.githubusercontent.com/2198138/73109237-d87d7e00-3ebf-11ea-81cf-2c89e2fa476b.png)
