### PR TITLE
Fix leading zero on DPAPI MK GUID

### DIFF
--- a/pypykatz/commons/win_datatypes.py
+++ b/pypykatz/commons/win_datatypes.py
@@ -206,11 +206,11 @@ class GUID:
 		self.Data3 = WORD(reader).value
 		self.Data4 = reader.read(8)
 		self.value = '-'.join([
-			hex(self.Data1)[2:], 
-			hex(self.Data2)[2:], 
-			hex(self.Data3)[2:], 
-			hex(int.from_bytes(self.Data4[:2], byteorder = 'big', signed = False))[2:],
-			hex(int.from_bytes(self.Data4[2:], byteorder = 'big', signed = False))[2:]
+			hex(self.Data1)[2:].zfill(8), 
+			hex(self.Data2)[2:].zfill(4), 
+			hex(self.Data3)[2:].zfill(4), 
+			hex(int.from_bytes(self.Data4[:2], byteorder = 'big', signed = False))[2:].zfill(4),
+			hex(int.from_bytes(self.Data4[2:], byteorder = 'big', signed = False))[2:].zfill(12)
 		])
 
 class PLIST_ENTRY(POINTER):


### PR DESCRIPTION
hex() is stripping output of leading zero which can lead to wrong GUID and wrong compare between blob GUID and MK GUID. 
E.g :  6f48f047-91-4922-b0c2-39d99bd99c81 instead of 6f48f047-0091-4922-b0c2-39d99bd99c81.
That's a quick fix, maybe it would be better to use format()