### PR TITLE
Fix bug in get_prekeys_from_password() to allow empty password

### DIFF
--- a/pypykatz/dpapi/dpapi.py
+++ b/pypykatz/dpapi/dpapi.py
@@ -161,7 +161,7 @@ class DPAPI:
 				nt_hash = bytes.fromhex(nt_hash)
 			key1 = None
 		
-		if password:
+		if password or password == '':
 			md4 = hashlib.new('md4')
 			md4.update(password.encode('utf-16le'))
 			nt_hash = md4.digest()


### PR DESCRIPTION
Fix tested on data from useraccount with empty password. It now works as expected when password="" is given as argument to method. Previously it would throw an Exception, as nt_hash would be None when key2 should be calculated.