### PR TITLE
Remove duplicate data

### DIFF
--- a/pypykatz/registry/sam/structures.py
+++ b/pypykatz/registry/sam/structures.py
@@ -197,7 +197,6 @@ class USER_ACCOUNT_V:
 		self.homedir_connect = None
 		self.script_path = None
 		self.profile_path = None
-		self.profile_path = None
 		self.workstations = None
 		self.hoursallowed = None
 		self.LM_hash = None


### PR DESCRIPTION
Just cleaning up a typo, where the same variable was declared twice.