### PR TITLE
Fixed get_lsass_pid(), using a better method

### DIFF
--- a/pypykatz/commons/readers/local/common/defines.py
+++ b/pypykatz/commons/readers/local/common/defines.py
@@ -701,7 +701,7 @@ class UNICODE_STRING(Structure):
     _fields_ = [
         ("Length",          USHORT),
         ("MaximumLength",   USHORT),
-        ("Buffer",          PVOID),
+        ("Buffer",          PWSTR),
     ]
 
 # From MSDN:

--- a/pypykatz/commons/readers/local/common/kernel32.py
+++ b/pypykatz/commons/readers/local/common/kernel32.py
@@ -609,3 +609,16 @@ class STARTUPINFOEXW(Structure):
         ('lpAttributeList', PPROC_THREAD_ATTRIBUTE_LIST),
     ]
 LPSTARTUPINFOEXW = POINTER(STARTUPINFOEXW)
+
+
+class SYSTEM_PROCESS_ID_INFORMATION(Structure):
+    _fields_ = (('ProcessId', HANDLE),
+                ('ImageName', UNICODE_STRING),
+                )
+
+class SYSTEM_INFORMATION_CLASS(ctypes.c_ulong):
+    def __repr__(self):
+        return '%s(%s)' % (type(self).__name__, self.value)
+
+
+SystemProcessIdInformation = SYSTEM_INFORMATION_CLASS(88)

--- a/pypykatz/commons/readers/local/common/live_reader_ctypes.py
+++ b/pypykatz/commons/readers/local/common/live_reader_ctypes.py
@@ -54,7 +54,7 @@ def QueryDosDevice(drive_letter):
     buf = ctypes.create_unicode_buffer(buffer_length)
     status = windll.kernel32.QueryDosDeviceW(drive_letter, buf, buffer_length)
     if status == 0:
-        raise WinErrorFromNtStatus(status)
+        raise ctypes.WinError()
     return buf.value
 
 

--- a/pypykatz/commons/readers/local/common/live_reader_ctypes.py
+++ b/pypykatz/commons/readers/local/common/live_reader_ctypes.py
@@ -80,7 +80,8 @@ DEVICE_PREFIXES = get_device_prefixes()
 PROCESS_QUERY_INFORMATION = 0x0400
 PROCESS_VM_READ = 0x0010
 MAXIMUM_ALLOWED = 33554432
-STATUS_INFO_LENGTH_MISMATCH = 0xC0000004
+STATUS_INFO_LENGTH_MISMATCH = -1073741820
+MAX_PATH_UNICODE = 1 << 15
 
 # Get full normalized image path of a process using NtQuerySystemInformation
 # It doesn't need any special privileges

--- a/pypykatz/commons/readers/local/common/live_reader_ctypes.py
+++ b/pypykatz/commons/readers/local/common/live_reader_ctypes.py
@@ -48,33 +48,88 @@ if getWindowsBuild() >= WindowsMinBuild.WIN_VISTA.value:
 else:
 	PROCESS_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0xFFF
 	
+
+def QueryDosDevice(drive_letter):
+    buffer_length = 1024
+    buf = ctypes.create_unicode_buffer(buffer_length)
+    status = windll.kernel32.QueryDosDeviceW(drive_letter, buf, buffer_length)
+    if status == 0:
+        raise WinErrorFromNtStatus(status)
+    return buf.value
+
+
+def get_drives():
+    drives = []
+    bitmask = windll.kernel32.GetLogicalDrives()
+    for letter in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ':
+        if bitmask & 1:
+            drives.append(letter + ':')
+        bitmask >>= 1
+    return drives
+
+def get_device_prefixes():
+    device_prefixes = {}
+    drives = get_drives()
+    for drive in drives:
+        device_prefixes[QueryDosDevice(drive)] = drive
+    return device_prefixes
+
+DEVICE_PREFIXES = get_device_prefixes()
+
+
 PROCESS_QUERY_INFORMATION = 0x0400
 PROCESS_VM_READ = 0x0010
 MAXIMUM_ALLOWED = 33554432
+STATUS_INFO_LENGTH_MISMATCH = 0xC0000004
 
-	
+# Get full normalized image path of a process using NtQuerySystemInformation
+# It doesn't need any special privileges
+def get_process_full_imagename(pid):
+    _NtQuerySystemInformation = windll.ntdll.NtQuerySystemInformation
+    image_filename = ''
+    buf = ctypes.create_unicode_buffer(0x1000)
+    process_info = SYSTEM_PROCESS_ID_INFORMATION()
+    process_info.ProcessId = ctypes.c_void_p(pid)
+    process_info.ImageName.MaximumLength = len(buf)
+    process_info.ImageName.Buffer = addressof(buf)
+    status = _NtQuerySystemInformation(
+        SystemProcessIdInformation,
+        process_info,
+        sizeof(process_info),
+        None)
+    if status == STATUS_INFO_LENGTH_MISMATCH:
+        buf = ctypes.create_unicode_buffer(MAX_PATH_UNICODE)
+        process_info.ImageName.MaximumLength = len(buf)
+        process_info.ImageName.Buffer = addressof(buf)
+        status = _NtQuerySystemInformation(
+            SystemProcessIdInformation,
+            process_info,
+            sizeof(process_info),
+            None)
+    if status == 0:
+        image_filename = str(process_info.ImageName.Buffer)
+        if image_filename.startswith('\\Device\\'):
+            for win_path in DEVICE_PREFIXES:
+                if image_filename.startswith(win_path):
+                    image_filename = DEVICE_PREFIXES[win_path] + image_filename[len(win_path):]
+    else:
+        image_filename = 'N/A'
+    return image_filename
+
 #https://msdn.microsoft.com/en-us/library/windows/desktop/ms683217(v=vs.85).aspx
 def enum_process_names():
-	pid_to_name = {}
+	pid_to_fullname = {}
 	
 	for pid in EnumProcesses():
 		if pid == 0:
 			continue
-		pid_to_name[pid] = 'Not found'
-		try:
-			process_handle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, False, pid)
-		except Exception as e:
-			continue
-			
-		pid_to_name[pid] = QueryFullProcessImageNameW(process_handle)
-	return pid_to_name
-	
+		pid_to_fullname[pid] = get_process_full_imagename(pid)
+	return pid_to_fullname
 	
 def get_lsass_pid():
 	pid_to_name = enum_process_names()
 	for pid in pid_to_name:
-		if pid_to_name[pid].lower().find('lsass.exe') != -1:
+		if pid_to_name[pid].lower().endswith(':\\windows\\system32\\lsass.exe'):
 			return pid
 			
 	raise Exception('Failed to find lsass.exe')
-	


### PR DESCRIPTION
Hello,

The function get_lsass_pid() won't work on systems with protected processes even with the Debug privilege.
I've used another method to retrieve the process infos which does not require any special privilege and doesn't need OpenProcess and QueryFullProcessImageNameW and also it retrieved the full path of the process.