### PR TITLE
fix error/warning in setup install

### DIFF
--- a/pypykatz/alsadecryptor/packages/kerberos/decryptor.py
+++ b/pypykatz/alsadecryptor/packages/kerberos/decryptor.py
@@ -84,7 +84,7 @@ class KerberosDecryptor(PackageDecryptor):
 		except Exception as e:
 			raise e
 	
-	def start(self):
+	async def start(self):
 		try:
 			entry_ptr_value, entry_ptr_loc = self.find_first_entry()
 		except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,11 @@ setup(
 
 	# long_description=open("README.txt").read(),
 	python_requires='>=3.6',
-	classifiers=(
+	classifiers=[
 		"Programming Language :: Python :: 3.6",
 		"License :: OSI Approved :: MIT License",
 		"Operating System :: OS Independent",
-	),
+	],
 	install_requires=[
 		'minidump>=0.0.17',
 		'minikerberos>=0.2.11',


### PR DESCRIPTION
Resolves Issue:  #82 

Fixes: 
- fixed error "'await' outside async function" and changed start to be an async function
- fixed warning "'classifiers' should be a list, got type 'tuple'", changed 'classifiers' tupel to a list 

Tested on: 
- Windows 10 1903
- python 3.9.4



