### PR TITLE
Fix pid to process name resolve

### DIFF
--- a/pypykatz/commons/winapi/local/function_defs/live_reader_ctypes.py
+++ b/pypykatz/commons/winapi/local/function_defs/live_reader_ctypes.py
@@ -18,9 +18,9 @@ class WindowsMinBuild(enum.Enum):
 	WIN_BLUE = 9400
 	WIN_10 = 9800
 
-	
+
 #utter microsoft bullshit commencing..
-def getWindowsBuild():   
+def getWindowsBuild():
     class OSVersionInfo(ctypes.Structure):
         _fields_ = [
             ("dwOSVersionInfoSize" , ctypes.c_int),
@@ -32,9 +32,9 @@ def getWindowsBuild():
     GetVersionEx = getattr( ctypes.windll.kernel32 , "GetVersionExA")
     version  = OSVersionInfo()
     version.dwOSVersionInfoSize = ctypes.sizeof(OSVersionInfo)
-    GetVersionEx( ctypes.byref(version) )    
+    GetVersionEx( ctypes.byref(version) )
     return version.dwBuildNumber
-	
+
 DELETE = 0x00010000
 READ_CONTROL = 0x00020000
 WRITE_DAC = 0x00040000
@@ -49,41 +49,41 @@ if getWindowsBuild() >= WindowsMinBuild.WIN_VISTA.value:
 	PROCESS_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0xFFFF
 else:
 	PROCESS_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0xFFF
-	
+
 PROCESS_QUERY_INFORMATION = 0x0400
 PROCESS_VM_READ = 0x0010
 
-	
+
 #https://msdn.microsoft.com/en-us/library/windows/desktop/ms683217(v=vs.85).aspx
 def enum_process_names():
 	pid_to_name = {}
-	
+
 	for pid in EnumProcesses():
 		if pid == 0:
 			continue
 		pid_to_name[pid] = 'Not found'
 		try:
 			process_handle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, False, pid)
+			pid_to_name[pid] = QueryFullProcessImageNameW(process_handle)
 		except Exception as e:
 			continue
-			
-		pid_to_name[pid] = QueryFullProcessImageNameW(process_handle)
+
 	return pid_to_name
-	
-	
+
+
 def get_lsass_pid():
 	pid_to_name = enum_process_names()
 	for pid in pid_to_name:
 		if pid_to_name[pid].lower().find('lsass.exe') != -1:
 			return pid
-			
+
 	raise Exception('Failed to find lsass.exe')
-	
+
 def enum_lsass_handles():
 	#searches for open LSASS process handles in all processes
 	# you should be having SE_DEBUG enabled at this point
 	RtlAdjustPrivilege(20)
-	
+
 	lsass_handles = []
 	sysinfohandles = NtQuerySystemInformation(16)
 	for pid in sysinfohandles:
@@ -98,14 +98,14 @@ def enum_lsass_handles():
 			except Exception as e:
 				logger.debug('Error opening process %s Reason: %s' % (pid, e))
 				continue
-			
+
 			try:
 				dupHandle = NtDuplicateObject(pHandle, syshandle.Handle, GetCurrentProcess(), PROCESS_QUERY_INFORMATION|PROCESS_VM_READ)
 				#print(dupHandle)
 			except Exception as e:
 				logger.debug('Failed to duplicate object! PID: %s HANDLE: %s' % (pid, hex(syshandle.Handle)))
 				continue
-				
+
 			oinfo = NtQueryObject(dupHandle, ObjectTypeInformation)
 			if oinfo.Name.getString() == 'Process':
 				try:
@@ -115,8 +115,7 @@ def enum_lsass_handles():
 						#print('%s : %s' % (pid, pname))
 						lsass_handles.append((pid, dupHandle))
 				except Exception as e:
-					logger.debug('Failed to obtain the path of the process! PID: %s' % pid) 
+					logger.debug('Failed to obtain the path of the process! PID: %s' % pid)
 					continue
-	
+
 	return lsass_handles
-	


### PR DESCRIPTION
Fixes: #90.
Now, if the method fails to resolve a pid to name, the resolve process continues instead of failing the whole mimikatz.