### PR TITLE
Fixes a crash when CredmanCredential.password_raw is None

### DIFF
--- a/pypykatz/lsadecryptor/packages/msv/decryptor.py
+++ b/pypykatz/lsadecryptor/packages/msv/decryptor.py
@@ -75,7 +75,7 @@ class CredmanCredential:
 		t += '\t\tusername %s\n' % self.username
 		t += '\t\tdomain %s\n' % self.domainname
 		t += '\t\tpassword %s\n' % self.password
-		t += '\t\tpassword (hex)%s\n' % self.password_raw.hex()
+		t += '\t\tpassword (hex)%s\n' % (self.password_raw.hex() if self.password_raw else '')
 		return t
 		
 		


### PR DESCRIPTION
For some reason, the `password_raw` attribute of the `CredmanCredential` object might be `None` when the object is printed, which crashes the output when dumping credentials.


Please note that this does not seem to be the case for `WDigestCredential.password_raw`, for which the value is `b''` when the password does not exist, but I didn't dive deep enough into the code to find out why.
You are welcome to change this fix if it is not the best way to deal with the bug

Cheers


__________
The original stacktrace :
```
Traceback (most recent call last):
  File "/usr/local/bin/pypykatz", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/dist-packages/pypykatz/__main__.py", line 84, in main
    helper.execute(args)
  File "/usr/local/lib/python3.9/dist-packages/pypykatz/lsadecryptor/cmdhelper.py", line 52, in execute
    self.run(args)
  File "/usr/local/lib/python3.9/dist-packages/pypykatz/lsadecryptor/cmdhelper.py", line 252, in run
    self.process_results(results, files_with_error, args)
  File "/usr/local/lib/python3.9/dist-packages/pypykatz/lsadecryptor/cmdhelper.py", line 131, in process_results
    print(str(results[result].logon_sessions[luid]))
  File "/usr/local/lib/python3.9/dist-packages/pypykatz/lsadecryptor/packages/msv/decryptor.py", line 191, in __str__
    t+= str(cred)
  File "/usr/local/lib/python3.9/dist-packages/pypykatz/lsadecryptor/packages/msv/decryptor.py", line 78, in __str__
    t += '\t\tpassword (hex)%s\n' % self.password_raw.hex()
AttributeError: 'NoneType' object has no attribute 'hex'
```