### PR TITLE
Minikerberos version 0.4.0 - cannot import name 'KerberosUserEnum' from 'minikerberos.security'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
 	install_requires=[
 		'unicrypto>=0.0.9',
 		'minidump>=0.0.21',
-		'minikerberos>=0.3.5',
+		'minikerberos==0.3.5',
 		'aiowinreg>=0.0.7',
 		'msldap>=0.4.1',
 		'winacl>=0.1.5',

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
 		'aiosmb>=0.4.2',
 		'aesedb>=0.1.0',
 		'tqdm',
+		'pycparser',
 	],
 	
 	# No more conveinent .exe entry point thanks to some idiot who 


### PR DESCRIPTION
Related to #117.