### PR TITLE
registry: add dump of default logon's password in text format

### DIFF
--- a/pypykatz/registry/software/software.py
+++ b/pypykatz/registry/software/software.py
@@ -62,4 +62,6 @@ class SOFTWARE:
 	def __str__(self):
 		t  = '============== SOFTWARE hive secrets ==============\r\n'
 		t += 'default_logon_user: %s\r\n' % self.default_logon_user
+		t += 'default_logon_domain: %s\r\n' % self.default_logon_domain
+		t += 'default_logon_password: %s\r\n' % self.default_logon_password
 		return t


### PR DESCRIPTION
When using `pypykatz registry`  in text mode (the default), user login is printed, but not its domain or password, while this information is there if we use --json. This commit adds the user domain and password to the text dump.
