### PR TITLE
Added windows 11 wDigest functionality

### DIFF
--- a/pypykatz/lsadecryptor/packages/wdigest/templates.py
+++ b/pypykatz/lsadecryptor/packages/wdigest/templates.py
@@ -35,8 +35,14 @@ class WdigestTemplate(PackageTemplate):
 				template.primary_offset = 48
 				template.list_entry = PWdigestListEntry
 
-			elif sysinfo.buildnumber >= WindowsMinBuild.WIN_VISTA.value:
+			elif WindowsMinBuild.WIN_VISTA.value <= sysinfo.buildnumber < WindowsMinBuild.WIN_11.value:
 				template.signature = b'\x48\x3b\xd9\x74'
+				template.first_entry_offset = -4
+				template.primary_offset = 48
+				template.list_entry = PWdigestListEntry
+
+			elif sysinfo.buildnumber >= WindowsMinBuild.WIN_11.value:
+				template.signature = b'\x48\x3b\xd8\x74'
 				template.first_entry_offset = -4
 				template.primary_offset = 48
 				template.list_entry = PWdigestListEntry


### PR DESCRIPTION
During a recent CTF there was a challenge to get the plaintext password from an lsass.exe dump on a windows 11 machine. Since wdigest is disabled by default in windows 11 there was no support for this in pypykatz, but by simply adding the following code, everything works as expected. 

Thanks again for a great tool :)
also added the lsass dump file from the CTF below so you can verify it works

[lsass.tar.gz](https://github.com/skelsec/pypykatz/files/15287284/lsass.tar.gz)
