### PR TITLE
chrome: fix crash on empty dpapi blob

### DIFF
--- a/pypykatz/dpapi/dpapi.py
+++ b/pypykatz/dpapi/dpapi.py
@@ -779,7 +779,7 @@ class DPAPI:
 						dec_val = cipher.decrypt(ciphertext, b'', tag)
 						results['cookies'].append((dbpaths[username]['cookies'], host_key, name, path, dec_val ))
 						results['fmtcookies'].append(DPAPI.cookieformatter('https://' + host_key, name, path, dec_val))
-					else:
+					elif encrypted_value:
 						dec_val = self.decrypt_blob_bytes(encrypted_value)
 						results['cookies'].append((dbpaths[username]['cookies'], host_key, name, path, dec_val ))
 						results['fmtcookies'].append(DPAPI.cookieformatter('https://' + host_key, name, path, dec_val))


### PR DESCRIPTION
Hey @skelsec, I stumbled upon a crash in the "chrome" module while processing cookies. The cause was an empty (`b''`) DPAPI blob. My fix is to just skip empty blobs.

Before the fix:

~~~
❯ pypykatz --verbose dpapi chrome --cookie ./tmp/Cookies ./tmp/masterkey.json ./tmp/Local\ State
DEBUG:pypykatz:== DPAPI_BLOB ==
version: 1
credential_guid: b'\xd0\x8c\x9d\xdf\x01\x15\xd1\x11\x8cz\x00\xc0O\xc2\x97\xeb'
masterkey_version: 1
masterkey_guid: 11ddd3f6-1ee2-4496-8ac0-e5bce3966101
flags: 16
description_length: 28
description: b'G\x00o\x00o\x00g\x00l\x00e\x00 \x00C\x00h\x00r\x00o\x00m\x00e\x00\x00\x00'
crypto_algorithm: 26115
crypto_algorithm_length: 192
salt_length: 16
salt: b"l'\x8d\xa2\x99\x06\xd8\x10\xd0@\x91\x8c=)M\xba"
HMAC_key_length: 0
HMAC_key: b''
hash_algorithm: 32772
HMAC: b'\xa3\xad\x8b\xbf\rO\xe6\\\x14\xa8G-[\xe8:Q'
data_length: 40
data: b'\xf1\r\xe7\x97\x87\xe4\xab\x85\xab\xf7/\xc0yz-/\x85\x161\xef^j\x9a\x0c\xf0;7\x8d\x8fA\x85Mm\x99\xd5\x8c\xe2;_v'
signature_length: 20
signature: b"D\xa4\xaa0\xc0\xedL4\xa5\x1a'\x8f\xe2\xa0\x1d\xc15{;b"
hash_algorithm_length: 160
HMAC_length: 16
to_sign: b"\x01\x00\x00\x00\xf6\xd3\xdd\x11\xe2\x1e\x96D\x8a\xc0\xe5\xbc\xe3\x96a\x01\x10\x00\x00\x00\x1c\x00\x00\x00G\x00o\x00o\x00g\x00l\x00e\x00 \x00C\x00h\x00r\x00o\x00m\x00e\x00\x00\x00\x03f\x00\x00\xc0\x00\x00\x00\x10\x00\x00\x00l'\x8d\xa2\x99\x06\xd8\x10\xd0@\x91\x8c=)M\xba\x00\x00\x00\x00\x04\x80\x00\x00\xa0\x00\x00\x00\x10\x00\x00\x00\xa3\xad\x8b\xbf\rO\xe6\\\x14\xa8G-[\xe8:Q(\x00\x00\x00\xf1\r\xe7\x97\x87\xe4\xab\x85\xab\xf7/\xc0yz-/\x85\x161\xef^j\x9a\x0c\xf0;7\x8d\x8fA\x85Mm\x99\xd5\x8c\xe2;_v"

DEBUG:pypykatz:[DPAPI] Looking for master key with GUID 11ddd3f6-1ee2-4496-8ac0-e5bce3966101
DEBUG:pypykatz:== DPAPI_BLOB ==
version: 0
credential_guid: b''
masterkey_version: 0
masterkey_guid: 00000000-0000-0000-0000-000000000000
flags: 0
description_length: 0
description: b''
crypto_algorithm: 0
crypto_algorithm_length: 0
salt_length: 0
salt: b''
HMAC_key_length: 0
HMAC_key: b''
hash_algorithm: 0
HMAC: b''
data_length: 0
data: b''
signature_length: 0
signature: b''
hash_algorithm_length: 0
HMAC_length: 0
to_sign: b''

DEBUG:pypykatz:[DPAPI] Looking for master key with GUID 00000000-0000-0000-0000-000000000000
Traceback (most recent call last):
  File "/home/daniel/projects/github/pypykatz/.venv/bin/pypykatz", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/daniel/projects/github/pypykatz/.venv/lib/python3.12/site-packages/pypykatz/__main__.py", line 89, in main
    helper.execute(args)
  File "/home/daniel/projects/github/pypykatz/.venv/lib/python3.12/site-packages/pypykatz/dpapi/cmdhelper.py", line 166, in execute
    self.run(args)
  File "/home/daniel/projects/github/pypykatz/.venv/lib/python3.12/site-packages/pypykatz/dpapi/cmdhelper.py", line 316, in run
    res = dpapi.decrypt_all_chrome(db_paths, throw=False)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/daniel/projects/github/pypykatz/.venv/lib/python3.12/site-packages/pypykatz/dpapi/dpapi.py", line 783, in decrypt_all_chrome
    dec_val = self.decrypt_blob_bytes(encrypted_value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/daniel/projects/github/pypykatz/.venv/lib/python3.12/site-packages/pypykatz/dpapi/dpapi.py", line 517, in decrypt_blob_bytes
    return self.decrypt_blob(blob, key = key, entropy = entropy)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/daniel/projects/github/pypykatz/.venv/lib/python3.12/site-packages/pypykatz/dpapi/dpapi.py", line 500, in decrypt_blob
    raise Exception('No matching masterkey was found for the blob!')
Exception: No matching masterkey was found for the blob!
~~~

Afterwards:

~~~
❯ pypykatz --verbose dpapi chrome --cookie ./tmp/Cookies ./tmp/masterkey.json ./tmp/Local\ State
DEBUG:pypykatz:== DPAPI_BLOB ==
version: 1
credential_guid: b'\xd0\x8c\x9d\xdf\x01\x15\xd1\x11\x8cz\x00\xc0O\xc2\x97\xeb'
masterkey_version: 1
masterkey_guid: 11ddd3f6-1ee2-4496-8ac0-e5bce3966101
flags: 16
description_length: 28
description: b'G\x00o\x00o\x00g\x00l\x00e\x00 \x00C\x00h\x00r\x00o\x00m\x00e\x00\x00\x00'
crypto_algorithm: 26115
crypto_algorithm_length: 192
salt_length: 16
salt: b"l'\x8d\xa2\x99\x06\xd8\x10\xd0@\x91\x8c=)M\xba"
HMAC_key_length: 0
HMAC_key: b''
hash_algorithm: 32772
HMAC: b'\xa3\xad\x8b\xbf\rO\xe6\\\x14\xa8G-[\xe8:Q'
data_length: 40
data: b'\xf1\r\xe7\x97\x87\xe4\xab\x85\xab\xf7/\xc0yz-/\x85\x161\xef^j\x9a\x0c\xf0;7\x8d\x8fA\x85Mm\x99\xd5\x8c\xe2;_v'
signature_length: 20
signature: b"D\xa4\xaa0\xc0\xedL4\xa5\x1a'\x8f\xe2\xa0\x1d\xc15{;b"
hash_algorithm_length: 160
HMAC_length: 16
to_sign: b"\x01\x00\x00\x00\xf6\xd3\xdd\x11\xe2\x1e\x96D\x8a\xc0\xe5\xbc\xe3\x96a\x01\x10\x00\x00\x00\x1c\x00\x00\x00G\x00o\x00o\x00g\x00l\x00e\x00 \x00C\x00h\x00r\x00o\x00m\x00e\x00\x00\x00\x03f\x00\x00\xc0\x00\x00\x00\x10\x00\x00\x00l'\x8d\xa2\x99\x06\xd8\x10\xd0@\x91\x8c=)M\xba\x00\x00\x00\x00\x04\x80\x00\x00\xa0\x00\x00\x00\x10\x00\x00\x00\xa3\xad\x8b\xbf\rO\xe6\\\x14\xa8G-[\xe8:Q(\x00\x00\x00\xf1\r\xe7\x97\x87\xe4\xab\x85\xab\xf7/\xc0yz-/\x85\x161\xef^j\x9a\x0c\xf0;7\x8d\x8fA\x85Mm\x99\xd5\x8c\xe2;_v"

DEBUG:pypykatz:[DPAPI] Looking for master key with GUID 11ddd3f6-1ee2-4496-8ac0-e5bce3966101
file: ./tmp/Cookies host_key: .google.com name: NID path: / value: b'515=pDm2HNaGBwdtqKMPW6lrYLsETcfUN2b-VIX9UzqfRZENPaWgfV49of55tQ7Pt1NAaVT7rmuoqBhJaPT23MrLjADl2UEx4WmxXNzArMSbel5_SihCy6BfLiQELTWglHdOIFekx_zEeolIECMS7KdyDqaynHgn8y7L1BrRJ3ds96Y'
file: ./tmp/Cookies host_key: chromewebstore.google.com name: OTZ path: / value: b'7616752_48_52_123900_48_436380'
...
~~~