### PR TITLE
Fixing Service User Bug

### DIFF
--- a/pypykatz/registry/system/system.py
+++ b/pypykatz/registry/system/system.py
@@ -63,7 +63,7 @@ class SYSTEM:
 		
 		try:
 			key = '%s\\Services\\%s\\ObjectName' % (self.currentcontrol, service_name)
-			return self.hive.get_value(key)[1].decode('utf-16-le')
+			return self.hive.get_value(key)[1]
 		except:
 			return None
 


### PR DESCRIPTION
This is to fix the issue #168 where a username is not displayed for service accounts.  Tested and this fixes the issue on windows 10, 2022 and 7.

![image](https://github.com/user-attachments/assets/0f9c74a9-6499-4129-bf4c-ad96428b2db3)
