### PR TITLE
Fix: decode unknown4 bytes properly

### DIFF
--- a/pypykatz/dpapi/structures/credentialfile.py
+++ b/pypykatz/dpapi/structures/credentialfile.py
@@ -188,7 +188,7 @@ class CREDENTIAL_BLOB:
 		
 		if sk.unknown4_length > 0:
 			try:
-				sk.unknown4_length = sk.unknown4_length.decode('utf-16-le')
+				sk.unknown4 = sk.unknown4.decode('utf-16-le')
 			except:
 				pass
 		


### PR DESCRIPTION
The unknown4 byte decode was decoding the length variable instead of the actual byte string, leading to the byte string being output instead of the cleartext password.