### PR TITLE
fix a length check that can be none (crashes)

### DIFF
--- a/pypykatz/dpapi/structures/credentialfile.py
+++ b/pypykatz/dpapi/structures/credentialfile.py
@@ -176,13 +176,16 @@ class CREDENTIAL_BLOB:
 				sk.description = sk.description.decode('utf-16-le')
 			except:
 				pass
-		sk.unknown3_length = int.from_bytes(buff.read(4), 'little', signed = False)
-		sk.unknown3_raw = buff.read(sk.unknown3_length)
-		if sk.unknown3_length > 0:
+		sk.unknown3_length = int.from_bytes(buff.read(4), 'little', signed=False)
+		if sk.unknown3_length:
+			sk.unknown3_raw = buff.read(sk.unknown3_length)
 			try:
 				sk.unknown3 = sk.unknown3_raw.decode('utf-16-le')
 			except:
 				sk.unknown3 = sk.unknown3_raw.hex()
+		else:
+			sk.unknown3_raw = b''
+			sk.unknown3     = ''
 		sk.username_length = int.from_bytes(buff.read(4), 'little', signed = False)
 		sk.username = buff.read(sk.username_length)
 		if sk.username_length > 0:
@@ -190,14 +193,16 @@ class CREDENTIAL_BLOB:
 				sk.username = sk.username.decode('utf-16-le')
 			except:
 				pass
-		sk.unknown4_length = int.from_bytes(buff.read(4), 'little', signed = False)
-		sk.unknown4_raw = buff.read(sk.unknown4_length)
-		
-		if sk.unknown4_length > 0:
+		sk.unknown4_length = int.from_bytes(buff.read(4), 'little', signed=False)
+		if sk.unknown4_length:
+			sk.unknown4_raw = buff.read(sk.unknown4_length)
 			try:
 				sk.unknown4 = sk.unknown4_raw.decode('utf-16-le')
 			except:
 				sk.unknown4 = sk.unknown4_raw.hex()
+		else:
+			sk.unknown4_raw = b''
+			sk.unknown4     = ''
 		
 		for _ in range(sk.attributes_count):
 			attr = CREDENTIAL_ATTRIBUTE.from_buffer(buff)


### PR DESCRIPTION
Fix: ensure unknown3/unknown4 are always initialized (length 0 → '') to prevent TypeError in to_text() when the field is absent.

```bash
$ pypykatz dpapi credential masterkey credential
Traceback (most recent call last):
  File "/home/charlie/.local/bin/pypykatz", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/opt/pypykatz/pypykatz/__main__.py", line 89, in main
    helper.execute(args)
    ~~~~~~~~~~~~~~^^^^^^
  File "/opt/pypykatz/pypykatz/dpapi/cmdhelper.py", line 168, in execute
    self.run(args)
    ~~~~~~~~^^^^^^
  File "/opt/pypykatz/pypykatz/dpapi/cmdhelper.py", line 258, in run
    print(cred_blob.to_text())
          ~~~~~~~~~~~~~~~~~^^
  File "/opt/pypykatz/pypykatz/dpapi/structures/credentialfile.py", line 218, in to_text
    if len(self.unknown3) > 0:
       ~~~^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```