### PR TITLE
[BUG] Delete all_hashes argument from get_hashes

### DIFF
--- a/pypykatz/kerberos/kerberos.py
+++ b/pypykatz/kerberos/kerberos.py
@@ -79,10 +79,10 @@ def roast_ccache(ccachefile, outfile = None):
 	cc = CCACHE.from_file(ccachefile)
 	if outfile:
 		with open(outfile, 'wb') as f:
-			for h in cc.get_hashes(all_hashes = True):
+			for h in cc.get_hashes():
 				f.write(h.encode() + b'\r\n')
 	else:
-		for h in cc.get_hashes(all_hashes = True):
+		for h in cc.get_hashes():
 			print(h)
 
 def del_ccache(ccachefile, index):


### PR DESCRIPTION
Hello,

I got the following error trying to get the hashcat format of an ccache ticket :
*Found in the documentation: <https://github.com/skelsec/pypykatz/wiki/Kerberos-ccache-roast-command>*

```bash
$ pypykatz kerberos ccache roast ticket.ccache                                     
Traceback (most recent call last):
  File "/opt/tools/piplibs/bin/pypykatz", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/tools/piplibs/lib/python3.11/site-packages/pypykatz/__main__.py", line 89, in main
    helper.execute(args)
  File "/opt/tools/piplibs/lib/python3.11/site-packages/pypykatz/kerberos/cmdhelper.py", line 169, in execute
    self.run(args)
  File "/opt/tools/piplibs/lib/python3.11/site-packages/pypykatz/kerberos/cmdhelper.py", line 355, in run
    roast_ccache(args.ccachefile, args.out_file)
  File "/opt/tools/piplibs/lib/python3.11/site-packages/pypykatz/kerberos/kerberos.py", line 85, in roast_ccache
    for h in cc.get_hashes(all_hashes = True):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: CCACHE.get_hashes() got an unexpected keyword argument 'all_hashes'
```

My PR delete the argument `all_hashes` which is not present anymore in the function `get_hashes` from the CCACHE class
*cf: <https://github.com/skelsec/minikerberos/commit/6962e64c3f9b50d689783e0b51f33db00fdb8971#diff-5222f827cbda33225e1701ff01de58dfca45ae42f397547b35e697b842839ed9L632>*
*<https://github.com/skelsec/minikerberos/blob/ea58f0d4d0ca8890abff6963eb40f7ff3f1a7ac2/minikerberos/common/ccache.py#L706>*