### PR TITLE
Fix architecture detection in Vol3Reader

### DIFF
--- a/pypykatz/commons/readers/volatility3/volreader.py
+++ b/pypykatz/commons/readers/volatility3/volreader.py
@@ -158,7 +158,8 @@ class Vol3Reader:
 			raise Exception('Unsupported Volatility Framework Version')
 		if not symbol_table_is_64bit:
 			self.processor_architecture = KatzSystemArchitecture.X86
-		self.processor_architecture = KatzSystemArchitecture.X64
+		else:
+			self.processor_architecture = KatzSystemArchitecture.X64
 
 	def align(self, alignment = None):
 		"""


### PR DESCRIPTION
Vol3Reader.get_arch always returned X64, so it misidentified 32-bit architectures. I updated the conditional to keep KatzSystemArchitecture.X86 whenever the symbol table is 32-bit.