### PR TITLE
fix ssp extraction

### DIFF
--- a/pypykatz/commons/common.py
+++ b/pypykatz/commons/common.py
@@ -363,6 +363,7 @@ class WindowsBuild(enum.Enum):
 	WIN_11_2022 = 20348
 	WIN_11_2023 = 22621
 	WIN_11_24H2 = 26100 #new
+	WIN_11_23H2 = 22631
 	
 class WindowsMinBuild(enum.Enum):
 	WIN_XP = 2500

--- a/pypykatz/lsadecryptor/package_commons.py
+++ b/pypykatz/lsadecryptor/package_commons.py
@@ -115,6 +115,9 @@ class PackageDecryptor:
 		"""
 		
 		dec_password = None
+		if self.package_name == 'Ssp':
+			segment_size = 8
+
 		temp = self.lsa_decryptor.decrypt(enc_password, segment_size=segment_size)
 		if temp and len(temp) > 0:
 			if bytes_expected == False:
@@ -200,6 +203,3 @@ class PackageDecryptor:
 				entry_ptr = entry.Flink
 			else:
 				break
-				
-				
-	

--- a/pypykatz/lsadecryptor/packages/ssp/templates.py
+++ b/pypykatz/lsadecryptor/packages/ssp/templates.py
@@ -31,10 +31,13 @@ class SspTemplate(PackageTemplate):
 				template.signature = b'\xc7\x47\x24\x43\x72\x64\x41\x48\x89\x47\x78\xff\x15'
 				template.first_entry_offset = 20
 				
-			elif sysinfo.buildnumber >= WindowsBuild.WIN_10_1507.value:
+			elif WindowsBuild.WIN_10_1507.value <= sysinfo.buildnumber < WindowsBuild.WIN_11_2022.value:
 				template.signature = b'\x24\x43\x72\x64\x41\xff\x15'
 				template.first_entry_offset = 14
-			
+			elif sysinfo.buildnumber > WindowsBuild.WIN_11_2022.value:
+				template.signature = b'\x24\x43\x72\x64\x41\x48\xff\x15'
+				template.first_entry_offset = 20
+
 			else:
 				#currently this doesnt make sense, but keeping it here for future use
 				raise Exception('Could not identify template! Architecture: %s sysinfo.buildnumber: %s' % (sysinfo.architecture, sysinfo.buildnumber))


### PR DESCRIPTION
Fixes extraction of SSP creds.

```
kali@kali:~/pypykatz$ pypykatz lsa minidump /tmp/out.dmp -p ssp
INFO:pypykatz:Parsing file /tmp/out.dmp
FILE: ======== /tmp/out.dmp =======
== Orphaned credentials ==
        == SSP [2f41d]==
                username rdpuser
                domainname 
                password Password1
                password (hex)500061007300730077006f007200640031000000
```