### PR TITLE
fix template error for build 20348

### DIFF
--- a/pypykatz/lsadecryptor/packages/ssp/templates.py
+++ b/pypykatz/lsadecryptor/packages/ssp/templates.py
@@ -35,7 +35,7 @@ class SspTemplate(PackageTemplate):
 				template.signature = b'\x24\x43\x72\x64\x41\xff\x15'
 				template.first_entry_offset = 14
 			
-			elif sysinfo.buildnumber > WindowsBuild.WIN_11_2022.value:
+			elif sysinfo.buildnumber >= WindowsBuild.WIN_11_2022.value:
 				template.signature = b'\x24\x43\x72\x64\x41\x48\xff\x15'
 				template.first_entry_offset = 20
 


### PR DESCRIPTION
Fixes "template not found" error for dump files from Windows Server 2022.