### PR TITLE
Fix get_service_user when decoding fails

### DIFF
--- a/pypykatz/registry/system/system.py
+++ b/pypykatz/registry/system/system.py
@@ -63,6 +63,8 @@ class SYSTEM:
 		if self.currentcontrol is None:
 			self.get_currentcontrol()
 		
+		val = None
+
 		try:
 			key = '%s\\Services\\%s\\ObjectName' % (self.currentcontrol, service_name)
 			val = self.hive.get_value(key)[1]
@@ -70,7 +72,7 @@ class SYSTEM:
 			val = val.replace('\x00', '')
 			return val
 		except:
-			return None
+			return val
 	
 	def get_machine_name(self):
 		if self.currentcontrol is None:


### PR DESCRIPTION
When decoding an username from `LSA Service User Secret` fails, no username is returned.
By creating the variable `val` before the `try` block every change before the exception is saved and can be returned in the `except` block.

`pypykatz registry system_hive --security security_hive`

~ Before
<img width="542" height="75" alt="before" src="https://github.com/user-attachments/assets/f2ec9a01-be9b-491b-9b60-1481005c980e" />

~ After
<img width="535" height="74" alt="after" src="https://github.com/user-attachments/assets/f925cfd9-6447-4430-95ad-d799467ff891" />

The registries can be downloaded for testing here: https://drive.google.com/file/d/17SzpOW1SdA2IUuO-PAGKb8lZ4U59ThGz/view?usp=sharing