### PR TITLE
fix(msv): use LIST_65 for all Windows 11 24H2 / Server 2025 builds

### DIFF
--- a/pypykatz/alsadecryptor/packages/msv/templates.py
+++ b/pypykatz/alsadecryptor/packages/msv/templates.py
@@ -63,14 +63,11 @@ class MsvTemplate(PackageTemplate):
 		
 		elif sysinfo.buildnumber < WindowsBuild.WIN_11_24H2.value:
 			template.list_entry = PKIWI_MSV1_0_LIST_63
-		
-		elif sysinfo.buildnumber < WindowsBuild.WIN_11_25H2.value:
-			if sysinfo.msv_dll_timestamp >= 0xd133958f:
-				template.list_entry = PKIWI_MSV1_0_LIST_65
-			else:
-				template.list_entry = PKIWI_MSV1_0_LIST_64
 
 		else:
+			# Two extra PVOIDs (unk_24h2_0, unk_24h2_1) precede UserName from build 26100 onward.
+			# Struct layout is unchanged across 24H2 and 25H2, see mimikatz
+			# KIWI_MSV1_0_LIST_64 (gentilkiwi/mimikatz, mimikatz/modules/sekurlsa/kuhl_m_sekurlsa_utils.h).
 			template.list_entry = PKIWI_MSV1_0_LIST_65
 		
 		template.log_template('list_entry', template.list_entry)

--- a/pypykatz/lsadecryptor/packages/msv/templates.py
+++ b/pypykatz/lsadecryptor/packages/msv/templates.py
@@ -61,13 +61,11 @@ class MsvTemplate(PackageTemplate):
 		
 		elif sysinfo.buildnumber < WindowsBuild.WIN_11_24H2.value:
 			template.list_entry = PKIWI_MSV1_0_LIST_63
-		
-		elif sysinfo.buildnumber < WindowsBuild.WIN_11_25H2.value:
-			# Two extra PVOIDs (unk_24h2_0, unk_24h2_1) precede UserName in this build range.
-			# Mirrors mimikatz KIWI_MSV1_0_LIST_64 (gentilkiwi/mimikatz, mimikatz/modules/sekurlsa/kuhl_m_sekurlsa_utils.h).
-			template.list_entry = PKIWI_MSV1_0_LIST_65
 
 		else:
+			# Two extra PVOIDs (unk_24h2_0, unk_24h2_1) precede UserName from build 26100 onward.
+			# Struct layout is unchanged across 24H2 and 25H2, see mimikatz
+			# KIWI_MSV1_0_LIST_64 (gentilkiwi/mimikatz, mimikatz/modules/sekurlsa/kuhl_m_sekurlsa_utils.h).
 			template.list_entry = PKIWI_MSV1_0_LIST_65
 
 		template.log_template('list_entry', template.list_entry)

--- a/pypykatz/lsadecryptor/packages/msv/templates.py
+++ b/pypykatz/lsadecryptor/packages/msv/templates.py
@@ -63,6 +63,8 @@ class MsvTemplate(PackageTemplate):
 			template.list_entry = PKIWI_MSV1_0_LIST_63
 		
 		elif sysinfo.buildnumber < WindowsBuild.WIN_11_25H2.value:
+			# Two extra PVOIDs (unk_24h2_0, unk_24h2_1) precede UserName in this build range.
+			# Mirrors mimikatz KIWI_MSV1_0_LIST_64 (gentilkiwi/mimikatz, mimikatz/modules/sekurlsa/kuhl_m_sekurlsa_utils.h).
 			template.list_entry = PKIWI_MSV1_0_LIST_65
 
 		else:

--- a/pypykatz/lsadecryptor/packages/msv/templates.py
+++ b/pypykatz/lsadecryptor/packages/msv/templates.py
@@ -63,10 +63,7 @@ class MsvTemplate(PackageTemplate):
 			template.list_entry = PKIWI_MSV1_0_LIST_63
 		
 		elif sysinfo.buildnumber < WindowsBuild.WIN_11_25H2.value:
-			if sysinfo.msv_dll_timestamp >= 0xd133958f:
-				template.list_entry = PKIWI_MSV1_0_LIST_65
-			else:
-				template.list_entry = PKIWI_MSV1_0_LIST_64
+			template.list_entry = PKIWI_MSV1_0_LIST_65
 
 		else:
 			template.list_entry = PKIWI_MSV1_0_LIST_65


### PR DESCRIPTION
Hello @skelsec 👋

This fixes the `msv_exception_please_report` crash on Windows 11 24H2 and Server 2025 (build 26100) reported in #191.

**What breaks and why**

https://github.com/skelsec/pypykatz/commit/631ef61 introduced a timestamp gate for the 24H2 list entry selection: DLL timestamps at or above `0xd133958f` get `PKIWI_MSV1_0_LIST_65`, everything below falls back to `PKIWI_MSV1_0_LIST_64`. It mirrors the same approach used for Win7/Win8 (`0x53480000`), where the struct genuinely changed partway through the build series depending on which DLL update was installed.

The problem is that the analogy does not hold for 24H2. The two extra PVOIDs (`unk_24h2_0`, `unk_24h2_1`) that precede `UserName` in the list entry (visible in mimikatz as [`KIWI_MSV1_0_LIST_64`](https://github.com/gentilkiwi/mimikatz/blob/master/mimikatz/modules/sekurlsa/kuhl_m_sekurlsa_utils.h)) are present across all build 26100 binaries. So any dump whose DLL timestamp falls below the threshold gets `LIST_64`, which is missing those two PVOIDs. The reader ends up 8 bytes ahead, `Domaine.Buffer` lands on the raw `Length`/`MaximumLength` bytes of the actual domain name string, and the bogus pointer crashes the parser.

For reference, https://github.com/skelsec/pypykatz/commit/e79e319 already showed the uncertainty here: before https://github.com/skelsec/pypykatz/commit/631ef61 the 24H2 branch carried an experimental `if msv_dll_timestamp == 28698614` check that hardcoded one specific dump's timestamp. The timestamp gate in https://github.com/skelsec/pypykatz/commit/631ef61 was the attempt to generalize that, but the underlying struct difference is not timestamp driven.

Mimikatz confirms it: its selection logic gates on build number only with no timestamp condition within the 24H2 range. Build 26100 always maps to `KIWI_MSV1_0_LIST_64` (their naming).

**The fix**

Remove the timestamp branch and unconditionally select `PKIWI_MSV1_0_LIST_65` for the entire `[WIN_11_24H2, WIN_11_25H2)` range.

Fixes #191

Regards,