### PR TITLE
fix(lsa): suppress expected PEB parsing noise from LSASS minidumps

### DIFF
--- a/pypykatz/pypykatz.py
+++ b/pypykatz/pypykatz.py
@@ -6,6 +6,7 @@
 
 import platform
 import json
+import logging
 import traceback
 import base64
 
@@ -24,6 +25,14 @@ from minidump.minidumpfile import MinidumpFile
 from minikerberos.common.ccache import CCACHE
 from minikerberos.common.kirbi import Kirbi
 from pypykatz._version import __version__
+
+class _SuppressPEBError(logging.Filter):
+	# minidump always attempts PEB parsing but LSASS dumps don't include TEB memory.
+	# The error is expected and non-fatal. Suppress it at the call site rather
+	# than downgrading the log level in the upstream library.
+	def filter(self, record):
+		return 'PEB parsing error' not in record.getMessage()
+
 
 class pypykatz:
 	def __init__(self, reader, sysinfo):
@@ -145,7 +154,12 @@ class pypykatz:
 	@staticmethod
 	def parse_minidump_file(filename, packages = ['all'], chunksize = 10*1024):
 		try:
-			minidump = MinidumpFile.parse(filename)
+			_filter = _SuppressPEBError()
+			logging.getLogger().addFilter(_filter)
+			try:
+				minidump = MinidumpFile.parse(filename)
+			finally:
+				logging.getLogger().removeFilter(_filter)
 			reader = minidump.get_reader().get_buffered_reader(segment_chunk_size=chunksize)
 			sysinfo = KatzSystemInfo.from_minidump(minidump)
 		except Exception as e:


### PR DESCRIPTION
Hello @skelsec 👋

When parsing an LSASS minidump, the root logger prints a traceback at every run:

```
ERROR:root:PEB parsing error!
Traceback (most recent call last):
  ...
KeyError: 'could not find memory segment for address ...'
```

This is not a bug. The minidump library always attempts PEB parsing by reading `TEB + 0x60`, but LSASS dumps don't include TEB memory. The exception is caught inside `minidump`'s `_parse()` and logged via `logging.exception`, which is the right level for an unexpected error. The problem is that for LSASS dumps this path is always taken, so the traceback is printed unconditionally even when everything else succeeds.

Downgrading the log level in the library would be wrong because it would hide the same message in contexts where it actually signals something unexpected. The right fix is to suppress it at the call site in pypykatz, where we know the context is an LSASS dump.

This adds a scoped `logging.Filter` that is attached to the root logger only for the duration of `MinidumpFile.parse()` and removed immediately after in a `finally` block. No other log messages are affected.

Regards,