### PR TITLE
Fix lsass MSV parsing Win11 25H2 (kernel build 26100, LIST_65)

### DIFF
--- a/pypykatz/lsadecryptor/packages/msv/decryptor.py
+++ b/pypykatz/lsadecryptor/packages/msv/decryptor.py
@@ -473,8 +473,80 @@ class MsvDecryptor(PackageDecryptor):
 		
 		self.current_logonsession.msv_creds.append(cred)
 	
+	def _autoselect_list_entry(self, entry_ptr_loc):
+		"""
+		On Win11 25H2 (build 26200 - a shared-servicing/enablement release over
+		24H2) the lsass binaries are still versioned 26100.8655 and the minidump
+		reports kernel build 26100. The real LogonSession layout matches
+		KIWI_MSV1_0_LIST_65, but the regular template selection
+		(MsvTemplate.get_template) sees build 26100, enters the conditional branch
+		and picks LIST_64 from the DLL PE timestamp -> UserName/Domaine are read
+		at shifted offsets, Domaine.Buffer becomes garbage (0x140012) and the walk
+		fails. PE timestamps of reproducible builds are not monotonic, so the
+		threshold based on them is unreliable. Here we pick the structure by
+		content: for the first non-empty entry we score how many fields each
+		candidate template reads as valid. Active on build 26100+ (covers both
+		24H2 and 25H2 dumps, which both report kernel build 26100).
+		"""
+		if self.sysinfo.architecture != KatzSystemArchitecture.X64:
+			return
+		if self.sysinfo.buildnumber < WindowsBuild.WIN_11_24H2.value:
+			return
+		from pypykatz.lsadecryptor.packages.msv.templates import (
+			PKIWI_MSV1_0_LIST_64, KIWI_MSV1_0_LIST_64,
+			PKIWI_MSV1_0_LIST_65, KIWI_MSV1_0_LIST_65)
+
+		# find the first non-empty list head to probe
+		probe_value = None
+		for i in range(self.logon_session_count):
+			self.reader.move(entry_ptr_loc)
+			for _ in range(i * 2):
+				self.reader.read_int()
+			head = self.decryptor_template.list_entry(self.reader)
+			if head.location != head.value:
+				probe_value = head.value
+				break
+		if probe_value is None:
+			return
+
+		# current KIWI struct (from the finaltype of a pointer instance)
+		self.reader.move(probe_value)
+		cur_pkiwi = self.decryptor_template.list_entry
+		cur_kiwi = self.decryptor_template.list_entry(self.reader).finaltype
+
+		def field_score(u):
+			# +2 for a readable non-empty string with a sane length/pointer,
+			# -5 for obvious garbage (unreadable/bad length), 0 for an empty field
+			try:
+				if u.Length == 0:
+					return 0
+				if u.Length % 2 != 0 or u.Length > 512 or u.Buffer == 0:
+					return -5
+				return 2 if u.read_string(self.reader) else 0
+			except Exception:
+				return -5
+
+		def score(kiwi_cls):
+			try:
+				self.reader.move(probe_value)
+				o = kiwi_cls(self.reader)
+				return field_score(o.UserName) + field_score(o.Domaine) + field_score(o.LogonServer)
+			except Exception:
+				return -100
+
+		# the current template goes first -> on a tie it is kept
+		candidates = [(cur_pkiwi, cur_kiwi),
+		              (PKIWI_MSV1_0_LIST_65, KIWI_MSV1_0_LIST_65),
+		              (PKIWI_MSV1_0_LIST_64, KIWI_MSV1_0_LIST_64)]
+		best_pkiwi, best_kiwi = max(candidates, key=lambda pk: score(pk[1]))
+		if best_pkiwi is not cur_pkiwi:
+			self.log('Autoselected MSV list template %s (was %s)' % (
+				best_kiwi.__name__, cur_kiwi.__name__))
+			self.decryptor_template.list_entry = best_pkiwi
+
 	def start(self):
 		entry_ptr_value, entry_ptr_loc = self.find_first_entry()
+		self._autoselect_list_entry(entry_ptr_loc)
 		for i in range(self.logon_session_count):
 			self.reader.move(entry_ptr_loc)
 			for x in range(i*2): #skipping offset in an architecture-agnostic way

--- a/tests/test_msv_autoselect.py
+++ b/tests/test_msv_autoselect.py
@@ -1,0 +1,166 @@
+"""
+Tests for MsvDecryptor._autoselect_list_entry (content-based selection of the
+LogonSession structure on Win11 25H2, which reports kernel build 26100 and ships
+lsass binaries versioned 26100.8655; there the regular PE-timestamp based
+selection mispicks KIWI_MSV1_0_LIST_64 instead of the real KIWI_MSV1_0_LIST_65,
+producing a garbage Domaine.Buffer (0x140012) and a failing walk).
+
+Run:
+    python3 -m unittest tests.test_msv_autoselect -v
+or (if pytest is available):
+    pytest tests/test_msv_autoselect.py -v
+
+The real-dump tests run only if the dump is available. Its path is taken from
+PYPYKATZ_TESTDUMP, defaulting to our repaired Win11 25H2 test minidump (binaries
+26100.8655, SystemInfo reports build 26100).
+The dump must already be processed by fix_lsass_minidump.py (backfill of the
+lsasrv .text pages), otherwise the LSA key is not found - a problem unrelated
+to the structure template.
+"""
+import os
+import unittest
+
+from pypykatz.commons.common import KatzSystemArchitecture, WindowsBuild
+from pypykatz.lsadecryptor.packages.msv.decryptor import MsvDecryptor
+from pypykatz.lsadecryptor.packages.msv.templates import (
+    PKIWI_MSV1_0_LIST_64, PKIWI_MSV1_0_LIST_65, KIWI_MSV1_0_LIST_64,
+)
+
+TESTDUMP = os.environ.get('PYPYKATZ_TESTDUMP', '/mnt/ssd/lsass-work/test.fixed.dmp')
+KNOWN_USER = 'user'
+KNOWN_NT = '57d583aa46d571502aad4bb7aea09c70'
+
+SENTINEL = object()  # marker meaning "list_entry was left untouched"
+
+
+class _Sysinfo:
+    def __init__(self, arch, build):
+        self.architecture = arch
+        self.buildnumber = build
+
+
+class _Template:
+    def __init__(self, list_entry):
+        self.list_entry = list_entry
+
+
+class _StubDecryptor:
+    """Minimal stub: in the guard branches _autoselect only reads sysinfo and
+    (on exit) decryptor_template.list_entry - no reader/list is needed."""
+    def __init__(self, arch, build):
+        self.sysinfo = _Sysinfo(arch, build)
+        self.decryptor_template = _Template(SENTINEL)
+        self.logon_session_count = 1
+        self.reader = None
+
+    def log(self, *a, **k):
+        raise AssertionError('log() must not be called in guard branches')
+
+
+class GuardTests(unittest.TestCase):
+    """Main regression guard: on non-24H2 and x86 dumps the autoselect must NOT
+    activate, so pypykatz behaviour on those builds is unchanged."""
+
+    def _run(self, arch, build):
+        stub = _StubDecryptor(arch, build)
+        # call the unbound method on the stub
+        MsvDecryptor._autoselect_list_entry(stub, entry_ptr_loc=0)
+        return stub.decryptor_template.list_entry
+
+    def test_skip_win10_19041(self):
+        self.assertIs(self._run(KatzSystemArchitecture.X64, 19041), SENTINEL)
+
+    def test_skip_win7_7601(self):
+        self.assertIs(self._run(KatzSystemArchitecture.X64, 7601), SENTINEL)
+
+    def test_skip_build_just_below_24h2(self):
+        # boundary: 26099 (< 26100) -> not activated
+        self.assertIs(self._run(KatzSystemArchitecture.X64,
+                                WindowsBuild.WIN_11_24H2.value - 1), SENTINEL)
+
+    def test_skip_x86_even_on_24h2(self):
+        # x86 -> early return even on 24H2
+        self.assertIs(self._run(KatzSystemArchitecture.X86,
+                                WindowsBuild.WIN_11_24H2.value), SENTINEL)
+
+    # --- Angry: malformed/edge sysinfo must not crash the method ---
+    def test_angry_zero_build(self):
+        self.assertIs(self._run(KatzSystemArchitecture.X64, 0), SENTINEL)
+
+    def test_angry_huge_build(self):
+        # future build > 24H2: the method must try to activate and therefore
+        # reach the reader access -> with reader=None that raises -> it must not
+        # silently swallow the failure in the guard, nor fail before the guard.
+        stub = _StubDecryptor(KatzSystemArchitecture.X64, 99999)
+        with self.assertRaises(Exception):
+            MsvDecryptor._autoselect_list_entry(stub, entry_ptr_loc=0)
+
+
+def _build_decryptor(pk):
+    from pypykatz.lsadecryptor import MsvTemplate, CredmanTemplate
+    dec = MsvDecryptor(
+        pk.reader,
+        MsvTemplate.get_template(pk.sysinfo),
+        pk.lsa_decryptor,
+        CredmanTemplate.get_template(pk.sysinfo),
+        pk.sysinfo,
+    )
+    return dec
+
+
+@unittest.skipUnless(os.path.exists(TESTDUMP), 'no test dump %s' % TESTDUMP)
+class RealDumpTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from pypykatz.pypykatz import pypykatz
+        cls.pk = pypykatz.parse_minidump_file(TESTDUMP)
+
+    def test_default_template_is_list64(self):
+        # document the bug itself: the regular selection yields LIST_64 here
+        from pypykatz.lsadecryptor import MsvTemplate
+        t = MsvTemplate.get_template(self.pk.sysinfo)
+        self.assertIs(t.list_entry, PKIWI_MSV1_0_LIST_64,
+                      'expected the regular (wrong) LIST_64 for this build')
+
+    def test_autoselect_switches_to_list65(self):
+        dec = _build_decryptor(self.pk)
+        self.assertIs(dec.decryptor_template.list_entry, PKIWI_MSV1_0_LIST_64)
+        _, entry_ptr_loc = dec.find_first_entry()
+        dec._autoselect_list_entry(entry_ptr_loc)
+        self.assertIs(dec.decryptor_template.list_entry, PKIWI_MSV1_0_LIST_65,
+                      'autoselect must switch to LIST_65 on this dump')
+
+    def test_end_to_end_nt_hash(self):
+        # full regular path (parse_minidump_file already ran the autoselect)
+        found = None
+        for ls in self.pk.logon_sessions.values():
+            if (ls.username or '').lower() == KNOWN_USER:
+                for c in ls.msv_creds:
+                    if c.NThash and c.NThash.hex() == KNOWN_NT:
+                        found = c
+        self.assertIsNotNone(found, 'expected NT hash of user "user" was not recovered')
+
+    def test_angry_without_autoselect_is_broken(self):
+        """Angry/control: parsing the first entry with the regular (wrong) LIST_64
+        yields a broken Domaine.Buffer (0x140012) and reading the string raises.
+        Proves the correct result is delivered by our autoselect, not anything else."""
+        dec = _build_decryptor(self.pk)  # default template = LIST_64, autoselect not called
+        _, loc = dec.find_first_entry()
+        probe = None
+        for i in range(dec.logon_session_count):
+            dec.reader.move(loc)
+            for _ in range(i * 2):
+                dec.reader.read_int()
+            head = PKIWI_MSV1_0_LIST_64(dec.reader)
+            if head.location != head.value:
+                probe = head.value
+                break
+        self.assertIsNotNone(probe, 'could not find a non-empty entry to probe')
+        dec.reader.move(probe)
+        o = KIWI_MSV1_0_LIST_64(dec.reader)
+        with self.assertRaises(Exception):
+            o.Domaine.read_string(dec.reader)  # 0x140012 -> not in process memory
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Hey! This is patch generated by Claude Code for my Win11 (26200 aka 26100) test machine with full updates. I cant test it fully because i dont have /mnt/hgfs/!SHARED/test_dumps/ok/ with test dumps. But i hope it will be good for you by idea/solution/etc. 


Fix MSV LogonSession template selection on Win11 24H2 (content-based autoselect)

On recent Win11 24H2 builds (e.g. 26100.8655) the real MSV1_0 LogonSession layout matches KIWI_MSV1_0_LIST_65, but MsvTemplate.get_template selects LIST_64 based on the msv1_0.dll PE timestamp. PE timestamps of reproducible builds are not monotonic, so the threshold comparison is unreliable: LIST_64 is chosen, UserName/Domaine are read at the wrong offsets, Domaine.Buffer becomes garbage (0x140012) and the MSV list walk fails with "Memory address 0x00140012 is not in process memory space" - no credentials are recovered.

Add MsvDecryptor._autoselect_list_entry(): for 24H2+ x64 dumps it probes the first non-empty logon session with the candidate templates and keeps the one whose UserName/Domaine/LogonServer fields read as valid strings. Builds older than 24H2 and x86 dumps are left untouched, so existing behaviour is preserved.

Add tests/test_msv_autoselect.py (stdlib unittest): guard tests proving the autoselect stays inactive on pre-24H2 and x86 builds, plus real-dump tests (skipped when the dump is absent) covering the LIST_64 -> LIST_65 switch and end-to-end NT hash extraction.